### PR TITLE
10-23-2022 Incident Editor Upgrades

### DIFF
--- a/Assets/Resources/IncidentData/Expand Borders.json
+++ b/Assets/Resources/IncidentData/Expand Borders.json
@@ -1,0 +1,77 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 7,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "3",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "Influence",
+          "evaluator": {
+            "$id": "4",
+            "$type": "Game.Incidents.IntegerEvaluator, Assembly-CSharp",
+            "propertyName": "Influence",
+            "Comparator": ">=",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "5",
+                  "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": true,
+                  "ExpressionType": 2,
+                  "constValue": 0,
+                  "chosenMethod": null,
+                  "chosenProperty": "ControlledTiles",
+                  "nextOperator": "^",
+                  "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "6",
+                  "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": 2,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+          },
+          "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        }
+      ]
+    }
+  },
+  "Actions": {
+    "$id": "7",
+    "$type": "Game.Incidents.IncidentActionContainer, Assembly-CSharp",
+    "incidentLog": "Expand Borders Log",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentAction, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "8",
+          "$type": "Game.Incidents.ExpandBordersAction, Assembly-CSharp",
+          "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "Context": null
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  }
+}

--- a/Assets/Resources/IncidentData/Expand Borders.json
+++ b/Assets/Resources/IncidentData/Expand Borders.json
@@ -2,7 +2,7 @@
   "$id": "1",
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 7,
+  "Weight": 5,
   "Criteria": {
     "$id": "2",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
@@ -57,7 +57,7 @@
   "Actions": {
     "$id": "7",
     "$type": "Game.Incidents.IncidentActionContainer, Assembly-CSharp",
-    "incidentLog": "Expand Borders Log",
+    "incidentLog": "some log",
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentAction, Assembly-CSharp]], mscorlib",
       "$values": [
@@ -71,7 +71,97 @@
     },
     "Deployers": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
-      "$values": []
+      "$values": [
+        {
+          "$id": "9",
+          "$type": "Game.Incidents.ContextDeployer, Assembly-CSharp",
+          "delayTime": 0,
+          "deploymentCriteria": {
+            "$type": "System.Collections.Generic.List`1[[Game.Incidents.DeploymentCriterium, Assembly-CSharp]], mscorlib",
+            "$values": [
+              {
+                "$id": "10",
+                "$type": "Game.Incidents.DeploymentCriterium, Assembly-CSharp",
+                "previousFieldID": 0,
+                "contextField": "{0} - Original Context",
+                "criteria": {
+                  "$id": "11",
+                  "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+                  "propertyName": "Influence",
+                  "evaluator": {
+                    "$id": "12",
+                    "$type": "Game.Incidents.IntegerEvaluator, Assembly-CSharp",
+                    "propertyName": "Influence",
+                    "Comparator": ">",
+                    "expressions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "13",
+                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                          "hasNextOperator": false,
+                          "ExpressionType": 0,
+                          "constValue": 0,
+                          "chosenMethod": null,
+                          "chosenProperty": null,
+                          "nextOperator": null,
+                          "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                        }
+                      ]
+                    },
+                    "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                }
+              }
+            ]
+          },
+          "incidentContext": {
+            "$id": "14",
+            "$type": "Game.Incidents.WarDeclaredContext, Assembly-CSharp",
+            "faction1": {
+              "$id": "15",
+              "$type": "Game.Incidents.DeployedContextActionField`1[[Game.Incidents.FactionContext, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.ContextDeployer, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "ActionFieldIDString": "None",
+              "Method": 1,
+              "ActionFieldID": 0,
+              "NameID": null,
+              "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "faction2": {
+              "$id": "16",
+              "$type": "Game.Incidents.DeployedContextActionField`1[[Game.Incidents.FactionContext, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.ContextDeployer, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "ActionFieldIDString": "None",
+              "Method": 1,
+              "ActionFieldID": 0,
+              "NameID": null,
+              "ContextType": "Game.Incidents.FactionContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "Provider": null,
+            "ContextType": "Game.Incidents.WarDeclaredContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "NumIncidents": 0,
+            "ParentID": 0
+          }
+        }
+      ]
     }
   }
 }

--- a/Assets/Resources/IncidentData/Expand Borders.json.meta
+++ b/Assets/Resources/IncidentData/Expand Borders.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6228dce21275dd9489f8a8d7fd0b8958
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Factions/Faction.cs
+++ b/Assets/Scripts/Factions/Faction.cs
@@ -37,6 +37,11 @@ namespace Game.Factions
 		public void UpdateContext()
 		{
 			context.Influence += 1;
+			if(context.TestInts == null)
+			{
+				context.TestInts = new Dictionary<IIncidentContext, int>();
+				context.TestInts.Add(this.context, 5);
+			}
 		}
 
 		public bool AttemptExpandBorder(int numTimes)

--- a/Assets/Scripts/Factions/Faction.cs
+++ b/Assets/Scripts/Factions/Faction.cs
@@ -36,10 +36,10 @@ namespace Game.Factions
 
 		public void UpdateContext()
 		{
-			throw new System.NotImplementedException();
+			context.Influence += 1;
 		}
 
-		public void AttemptExpandBorder(int numTimes)
+		public bool AttemptExpandBorder(int numTimes)
 		{
 			HexCellPriorityQueue searchFrontier = new HexCellPriorityQueue();
 			int searchFrontierPhase = 1;
@@ -59,7 +59,7 @@ namespace Game.Factions
 				else
 				{
 					OutputLogger.LogError("Couldn't find free tile to create faction on!");
-					return;
+					return false;
 				}
 			}
 
@@ -93,6 +93,8 @@ namespace Game.Factions
 			}
 
 			SimulationManager.Instance.HexGrid.ResetSearchPhases();
+
+			return size != 0;
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/ContextDeployer.cs
+++ b/Assets/Scripts/Incidents/ContextDeployer.cs
@@ -10,10 +10,12 @@ namespace Game.Incidents
 		public int delayTime = 0;
 
 		[TypeFilter("GetFilteredTypeList"), OnValueChanged("SetContextType"), LabelText("Incident Type")]
-		public IIncidentContext incidentContext;
+		public IDeployableContext incidentContext;
 
-		public void Deploy()
+		public void Deploy(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
 		{
+			incidentContext.CalculateFields(context, delayedCalculateAction);
+
 			if(delayTime == 0)
 			{
 				IncidentService.Instance.PerformIncidents(incidentContext);
@@ -26,17 +28,65 @@ namespace Game.Incidents
 
 		private IEnumerable<Type> GetFilteredTypeList()
 		{
-			var q = typeof(IIncidentContext).Assembly.GetTypes()
+			var q = typeof(IDeployableContext).Assembly.GetTypes()
 				.Where(x => !x.IsAbstract)                                          // Excludes BaseClass
 				.Where(x => !x.IsGenericTypeDefinition)                             // Excludes C1<>
-				.Where(x => typeof(IIncidentContext).IsAssignableFrom(x));          // Excludes classes not inheriting from BaseClass
+				.Where(x => typeof(IDeployableContext).IsAssignableFrom(x));          // Excludes classes not inheriting from BaseClass
 
 			return q;
 		}
 
 		void SetContextType()
 		{
+			var fields = incidentContext.GetType().GetFields();
+			var matchingFields = fields.Where(x => x.FieldType.IsGenericType && x.FieldType.GetGenericTypeDefinition() == typeof(DeployedContextActionField<>)).ToList();
 
+			foreach (var field in matchingFields)
+			{
+				field.SetValue(incidentContext, Activator.CreateInstance(field.FieldType, this.GetType()));
+			}
 		}
+	}
+
+	public interface IDeployableContext : IIncidentContext
+	{
+		bool CalculateFields(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction);
+	}
+
+	public abstract class DeployableContext : IDeployableContext
+	{
+		public IIncidentContextProvider Provider => null;
+
+		public Type ContextType => this.GetType();
+
+		[ShowInInspector]
+		public int NumIncidents { get; set; }
+
+		public int ParentID { get; set; }
+
+		public bool CalculateFields(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
+		{
+			var fields = ContextType.GetFields();
+			var matchingFields = fields.Where(x => x.FieldType.IsGenericType && x.FieldType.GetGenericTypeDefinition() == typeof(DeployedContextActionField<>)).ToList();
+
+			foreach (var field in matchingFields)
+			{
+				var actionField = field.GetValue(this) as IIncidentActionField;
+				if (!actionField.CalculateField(context, delayedCalculateAction))
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+	}
+
+	public class WarDeclaredContext : DeployableContext
+	{
+		[HideReferenceObjectPicker]
+		public DeployedContextActionField<FactionContext> faction1;
+		[HideReferenceObjectPicker]
+		public DeployedContextActionField<FactionContext> faction2;
 	}
 }

--- a/Assets/Scripts/Incidents/Editor/LearnAboutReflectionEditor.cs
+++ b/Assets/Scripts/Incidents/Editor/LearnAboutReflectionEditor.cs
@@ -54,6 +54,11 @@ namespace Game.Incidents
 
 				faction.DeployContext();
 			}
+
+			if(GUILayout.Button("In game test!"))
+			{
+				SimulationManager.Instance.DebugRun();
+			}
 		}
 		public static IEnumerable<Type> GetAllTypesImplementingOpenGenericType(Type openGenericType, Assembly assembly)
 		{

--- a/Assets/Scripts/Incidents/Editor/LearnAboutReflectionEditor.cs
+++ b/Assets/Scripts/Incidents/Editor/LearnAboutReflectionEditor.cs
@@ -42,8 +42,7 @@ namespace Game.Incidents
 			{
 				var faction = new Faction();
 				faction.context.Population = 14;
-				faction.context.GooPercentage = 40f;
-				faction.context.IsFun = true;
+
 				var faction2 = new Faction();
 				faction2.context.Population = 5;
 

--- a/Assets/Scripts/Incidents/IContextDeployer.cs
+++ b/Assets/Scripts/Incidents/IContextDeployer.cs
@@ -1,7 +1,9 @@
-﻿namespace Game.Incidents
+﻿using System;
+
+namespace Game.Incidents
 {
 	public interface IContextDeployer
 	{
-		void Deploy();
+		void Deploy(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction);
 	}
 }

--- a/Assets/Scripts/Incidents/ICriteriaEvaluator.cs
+++ b/Assets/Scripts/Incidents/ICriteriaEvaluator.cs
@@ -16,6 +16,7 @@ namespace Game.Incidents
 	{
         [HideInInspector]
         public Type Type => typeof(T);
+        public Type ContextType { get; set; }
 
         private string comparator;
 
@@ -34,7 +35,7 @@ namespace Game.Incidents
         public bool Evaluate(IIncidentContext context, string propertyName)
         {
             var propertyValue = (T)context.GetType().GetProperty(propertyName).GetValue(context);
-            return Comparators[Comparator].Invoke(propertyValue, CombineExpressions());
+            return Comparators[Comparator].Invoke(propertyValue, CombineExpressions(context));
         }
 
         public CriteriaEvaluator()
@@ -45,8 +46,6 @@ namespace Game.Incidents
         public CriteriaEvaluator(string propertyName) : this()
 		{
             this.propertyName = propertyName;
-            expressions = new List<Expression<T>>();
-            expressions.Add(new Expression<T>());
         }
 
         public CriteriaEvaluator(string propertyName, T value) : this(propertyName)
@@ -54,21 +53,28 @@ namespace Game.Incidents
             expressions[0].constValue = value;
         }
 
+        public CriteriaEvaluator(string propertyName, Type contextType) : this(propertyName)
+		{
+            ContextType = contextType;
+            expressions = new List<Expression<T>>();
+            expressions.Add(new Expression<T>(ContextType));
+        }
+
         abstract protected void Setup();
 
-        public T CombineExpressions()
+        public T CombineExpressions(IIncidentContext context)
         {
-            var currentValue = expressions[0].Value;
+            var currentValue = expressions[0].GetValue(context);
             for (int i = 0; i < expressions.Count - 1; i++)
             {
-                currentValue = Operators[expressions[i].nextOperator].Invoke(currentValue, expressions[i + 1].Value);
+                currentValue = Operators[expressions[i].nextOperator].Invoke(currentValue, expressions[i + 1].GetValue(context));
             }
             return currentValue;
         }
 
         private void AddNewExpression()
         {
-            expressions.Add(new Expression<T>());
+            expressions.Add(new Expression<T>(ContextType));
             for (int i = 0; i < expressions.Count - 1; i++)
             {
                 expressions[i].hasNextOperator = true;
@@ -92,6 +98,7 @@ namespace Game.Incidents
         public IntegerEvaluator() : base() { }
         public IntegerEvaluator(string propertyName) : base(propertyName) { }
         public IntegerEvaluator(string propertyName, int value) : base(propertyName, value) { }
+        public IntegerEvaluator(string propertyName, Type contextType) : base(propertyName, contextType) { }
 
         override protected void Setup()
 		{
@@ -105,6 +112,7 @@ namespace Game.Incidents
         public FloatEvaluator() : base() { }
         public FloatEvaluator(string propertyName) : base(propertyName) { }
         public FloatEvaluator(string propertyName, float value) : base(propertyName, value) { }
+        public FloatEvaluator(string propertyName, Type contextType) : base(propertyName, contextType) { }
 
         override protected void Setup()
         {
@@ -118,6 +126,7 @@ namespace Game.Incidents
         public BoolEvaluator() : base() { }
         public BoolEvaluator(string propertyName) : base(propertyName) { }
         public BoolEvaluator(string propertyName, bool value) : base(propertyName, value) { }
+        public BoolEvaluator(string propertyName, Type contextType) : base(propertyName, contextType) { }
 
         override protected void Setup()
         {

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ExpandBordersAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ExpandBordersAction.cs
@@ -25,6 +25,8 @@ namespace Game.Incidents
 				{
 					factionContext.Influence = 0;
 				}
+
+				OutputLogger.Log("Borders expanded!");
 			}
 		}
 /*

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ExpandBordersAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ExpandBordersAction.cs
@@ -15,8 +15,17 @@ namespace Game.Incidents
 			//Once chosen, add those cell coordinates to faction's list of controlled tiles
 			//Perhaps perform some confirmation action
 			//Send out a TileClaimed context? I guess this is part of the actual incident not this action.
-			var faction = context.Provider as Faction;
-			faction.AttemptExpandBorder(1);
+			var factionContext = context as FactionContext;
+			var faction = factionContext.Provider as Faction;
+			var completed = faction.AttemptExpandBorder(1);
+			if(completed)
+			{
+				factionContext.Influence -= (int)Math.Pow(factionContext.ControlledTiles, 2);
+				if (factionContext.Influence < 0)
+				{
+					factionContext.Influence = 0;
+				}
+			}
 		}
 
 		public override void UpdateEditor()

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ExpandBordersAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ExpandBordersAction.cs
@@ -27,14 +27,16 @@ namespace Game.Incidents
 				}
 			}
 		}
-
+/*
 		public override void UpdateEditor()
 		{
 		}
-
+*/
+/*
 		protected override bool VerifyContextActionFields(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
 		{
 			return true;
 		}
+*/
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ExpandBordersAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ExpandBordersAction.cs
@@ -1,0 +1,31 @@
+﻿using Game.Factions;
+using Game.Terrain;
+using System;
+
+namespace Game.Incidents
+{
+	public class ExpandBordersAction : IncidentAction<FactionContext>
+	{
+		public override void PerformAction(IIncidentContext context)
+		{
+			//Calculate the cell that is best within the ones closest to the current center that arent unclaimed.
+			//Can allow for a little wiggle room for more interesting generation
+			//Maybe later add some resource or other based criteria for increasing tile weight
+
+			//Once chosen, add those cell coordinates to faction's list of controlled tiles
+			//Perhaps perform some confirmation action
+			//Send out a TileClaimed context? I guess this is part of the actual incident not this action.
+			var faction = context.Provider as Faction;
+			faction.AttemptExpandBorder(1);
+		}
+
+		public override void UpdateEditor()
+		{
+		}
+
+		protected override bool VerifyContextActionFields(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
+		{
+			return true;
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ExpandBordersAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ExpandBordersAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f34be54f29bac6146ba4d84e37b334a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/TestFactionIncidentAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/TestFactionIncidentAction.cs
@@ -14,22 +14,23 @@ namespace Game.Incidents
 		{
 			PerformDebugAction();
 		}
-
+/*
 		protected override bool VerifyContextActionFields(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
 		{
 			var succeeded = requiredFaction.CalculateField(context, delayedCalculateAction);
 			return succeeded;
 		}
-
+*/
 		private void PerformDebugAction()
 		{
 			OutputLogger.Log("Faction Debug Action Performed!");
 		}
-
+/*
 		public override void UpdateEditor()
 		{
 			requiredFaction = new IncidentContextActionField<FactionContext>(ContextType);
 			requiredFaction.criteria = new List<IIncidentCriteria>();
 		}
+*/
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/IIncidentActionField.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IIncidentActionField.cs
@@ -13,4 +13,32 @@ namespace Game.Incidents
 		bool CalculateField(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction);
 		IIncidentContextProvider GetFieldValue();
 	}
+
+	public class ConstantActionField : IIncidentActionField
+	{
+		public int ActionFieldID { get; set; }
+		public string ActionFieldIDString => "{" + ActionFieldID + "}";
+		public string NameID { get; set; }
+
+		public Type ContextType { get; set; }
+
+		private IIncidentContext context;
+
+		public ConstantActionField(Type contextType)
+		{
+			ContextType = contextType;
+			ActionFieldID = 0;
+			NameID = "{0} - Original Context";
+		}
+		public bool CalculateField(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
+		{
+			this.context = context;
+			return true;
+		}
+
+		public IIncidentContextProvider GetFieldValue()
+		{
+			return context?.Provider;
+		}
+	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
@@ -30,15 +30,7 @@ namespace Game.Incidents
 			return VerifyContextActionFields(context, delayedCalculateAction);
 		}
 
-		virtual public void PerformAction(IIncidentContext context)
-		{
-			PerformDebugAction();
-		}
-
-		private void PerformDebugAction()
-		{
-			OutputLogger.Log("Debug Action Performed!");
-		}
+		abstract public void PerformAction(IIncidentContext context);
 
 		abstract public void UpdateEditor();
 		abstract protected bool VerifyContextActionFields(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction);

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace Game.Incidents
 {
@@ -32,7 +33,31 @@ namespace Game.Incidents
 
 		abstract public void PerformAction(IIncidentContext context);
 
-		abstract public void UpdateEditor();
-		abstract protected bool VerifyContextActionFields(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction);
+		public void UpdateEditor()
+		{
+			var fields = this.GetType().GetFields();
+			var matchingFields = fields.Where(x => x.FieldType.IsGenericType && x.FieldType.GetGenericTypeDefinition() == typeof(IncidentContextActionField<>)).ToList();
+
+			foreach (var field in matchingFields)
+			{
+				field.SetValue(this, Activator.CreateInstance(field.FieldType, ContextType));
+			}
+		}
+		protected bool VerifyContextActionFields(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
+		{
+			var fields = this.GetType().GetFields();
+			var matchingFields = fields.Where(x => x.FieldType.IsGenericType && x.FieldType.GetGenericTypeDefinition() == typeof(IncidentContextActionField<>)).ToList();
+
+			foreach (var field in matchingFields)
+			{
+				var actionField = field.GetValue(this) as IIncidentActionField;
+				if(!actionField.CalculateField(context, delayedCalculateAction))
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentActionContainer.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentActionContainer.cs
@@ -9,6 +9,8 @@ namespace Game.Incidents
 		public List<IIncidentAction> Actions { get; set; }
 		public List<IContextDeployer> Deployers { get; set; }
 
+		private IIncidentContext providedContext;
+
 		public IncidentActionContainer(List<IIncidentAction> actions, List<IContextDeployer> deployers, string log)
 		{
 			Actions = actions;
@@ -18,6 +20,8 @@ namespace Game.Incidents
 
 		public bool PerformActions(IIncidentContext context, ref IncidentReport report)
 		{
+			providedContext = context;
+
 			foreach(var action in Actions)
 			{
 				if(!action.VerifyAction(context, GetProviderFromActionFields))
@@ -46,6 +50,7 @@ namespace Game.Incidents
 		public Dictionary<string, IIncidentContextProvider> GetContextProviderDictionary(IIncidentContext context)
 		{
 			var providerDictionary = new Dictionary<string, IIncidentContextProvider>();
+			providerDictionary.Add("{0}", context.Provider);
 
 			foreach (var action in Actions)
 			{
@@ -65,6 +70,11 @@ namespace Game.Incidents
 
 		public IIncidentActionField GetProviderFromActionFields(int actionFieldID)
 		{
+			if(actionFieldID == 0)
+			{
+				return new ConstantActionField(providedContext.ContextType);
+			}
+
 			foreach (var action in Actions)
 			{
 				var actionType = action.GetType();

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentActionContainer.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentActionContainer.cs
@@ -37,7 +37,7 @@ namespace Game.Incidents
 
 			foreach(var deployer in Deployers)
 			{
-				deployer.Deploy();
+				deployer.Deploy(context, GetProviderFromActionFields);
 			}
 
 			return true;

--- a/Assets/Scripts/Incidents/IncidentContextActionField.cs
+++ b/Assets/Scripts/Incidents/IncidentContextActionField.cs
@@ -15,8 +15,8 @@ namespace Game.Incidents
 		[HideInInspector]
 		public Type parentType;
 
-		[OnValueChanged("RetrievalTypeChanged")]
-		public ActionFieldRetrievalMethod Method;
+		[OnValueChanged("RetrievalTypeChanged"), ShowInInspector, PropertyOrder(-1)]
+		virtual public ActionFieldRetrievalMethod Method { get; set; }
 
 		[ShowIf("@this.ParentTypeMatches"), HideIf("@this.Method == ActionFieldRetrievalMethod.From_Previous")]
 		public bool AllowSelf;
@@ -35,7 +35,7 @@ namespace Game.Incidents
 		public string NameID { get; set; }
 
 		[ShowInInspector]
-		public string ActionFieldIDString => "{" + ActionFieldID + "}";
+		virtual public string ActionFieldIDString => "{" + ActionFieldID + "}";
 
 		public Type ContextType => typeof(T);
 		private bool ParentTypeMatches => parentType == typeof(T);
@@ -47,6 +47,7 @@ namespace Game.Incidents
 		public IncidentContextActionField(Type parentType)
 		{
 			this.parentType = parentType;
+
 			RetrievalTypeChanged();
 		}
 
@@ -134,6 +135,16 @@ namespace Game.Incidents
 		private void SetPreviousFieldID()
 		{
 			previousFieldID = IncidentEditorWindow.actionFields.Find(x => x.NameID == previousField).ActionFieldID;
+		}
+	}
+
+	public class DeployedContextActionField<T> : IncidentContextActionField<T> where T : IIncidentContext
+	{
+		[ShowInInspector]
+		override public string ActionFieldIDString => "None";
+
+		public DeployedContextActionField(Type parentType) : base(parentType)
+		{
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentContexts/FactionContext.cs
+++ b/Assets/Scripts/Incidents/IncidentContexts/FactionContext.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using Game.Factions;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace Game.Incidents
 {
@@ -10,7 +13,10 @@ namespace Game.Incidents
 		public int NumIncidents { get; set; }
 		public int ParentID => -1;
 		public int Population { get; set; }
-		public float GooPercentage { get; set; }
-		public bool IsFun { get; set; }
+		public int Influence { get; set; }
+		public int ControlledTiles => controlledTileIndices.Count;
+
+		[HideInInspector]
+		public List<int> controlledTileIndices;
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentContexts/FactionContext.cs
+++ b/Assets/Scripts/Incidents/IncidentContexts/FactionContext.cs
@@ -14,6 +14,7 @@ namespace Game.Incidents
 		public int ParentID => -1;
 		public int Population { get; set; }
 		public int Influence { get; set; }
+		public Dictionary<IIncidentContext, int> TestInts { get; set; }
 		public int ControlledTiles => controlledTileIndices.Count;
 
 		[HideInInspector]

--- a/Assets/Scripts/Incidents/IncidentCriteria.cs
+++ b/Assets/Scripts/Incidents/IncidentCriteria.cs
@@ -9,7 +9,7 @@ namespace Game.Incidents
     {
         public Type ContextType { get; set; }
         public Type PrimitiveType { get; set; }
-        private static Dictionary<string, Type> properties;
+        private Dictionary<string, Type> properties;
 
         [ValueDropdown("GetPropertyNames"), OnValueChanged("SetPrimitiveType"), HorizontalGroup("Group 1")]
         public string propertyName;
@@ -74,15 +74,15 @@ namespace Game.Incidents
 
             if (PrimitiveType == typeof(int))
             {
-                evaluator = new IntegerEvaluator(propertyName);
+                evaluator = new IntegerEvaluator(propertyName, ContextType);
             }
             else if(PrimitiveType == typeof(float))
 			{
-                evaluator = new FloatEvaluator(propertyName);
+                evaluator = new FloatEvaluator(propertyName, ContextType);
 			}
             else if(PrimitiveType == typeof(bool))
 			{
-                evaluator = new BoolEvaluator(propertyName);
+                evaluator = new BoolEvaluator(propertyName, ContextType);
 			}
         }
 

--- a/Assets/Scripts/Incidents/IncidentCriteria.cs
+++ b/Assets/Scripts/Incidents/IncidentCriteria.cs
@@ -51,13 +51,22 @@ namespace Game.Incidents
                 var propertyInfo = ContextType.GetProperties();
                 var interfacePropertyInfo = typeof(IIncidentContext).GetProperties();
 
-                var validProperties = propertyInfo.Where(x => !interfacePropertyInfo.Any(y => x.Name == y.Name)).ToList();
+                var validProperties = propertyInfo.Where(x => !interfacePropertyInfo.Any(y => x.Name == y.Name) && IsValidPropertyType(x.PropertyType)).ToList();
 
                 properties.Clear();
 
                 validProperties.ForEach(x => properties.Add(x.Name, x.PropertyType));
             }
         }
+
+        private bool IsValidPropertyType(Type type)
+		{
+            return type == typeof(int) || type == typeof(float) || type == typeof(bool)
+                || type == typeof(Dictionary<IIncidentContext, int>)
+                || type == typeof(Dictionary<IIncidentContext, float>)
+                || type == typeof(Dictionary<IIncidentContext, bool>)
+                || type == typeof(List<IIncidentContext>);
+		}
 
         private IEnumerable<string> GetPropertyNames()
         {
@@ -84,6 +93,28 @@ namespace Game.Incidents
 			{
                 evaluator = new BoolEvaluator(propertyName, ContextType);
 			}
+            else if(PrimitiveType == typeof(Dictionary<IIncidentContext,int>))
+			{
+                OutputLogger.Log("Found Complex Type");
+                evaluator = new IntegerValueDictionaryEvaluator(propertyName, ContextType);
+			}
+            else if (PrimitiveType == typeof(Dictionary<IIncidentContext, float>))
+            {
+                OutputLogger.Log("Found Complex Type");
+                evaluator = new FloatValueDictionaryEvaluator(propertyName, ContextType);
+            }
+            else if (PrimitiveType == typeof(Dictionary<IIncidentContext, bool>))
+            {
+                OutputLogger.Log("Found Complex Type");
+                evaluator = new BoolValueDictionaryEvaluator(propertyName, ContextType);
+            }
+            else if (PrimitiveType == typeof(List<IIncidentContext>))
+            {
+                OutputLogger.Log("Found Complex Type");
+                evaluator = new ListEvaluator(propertyName, ContextType);
+            }
+
+            //PrimitiveType.IsGenericType && PrimitiveType.GetGenericTypeDefinition() == typeof(Dictionary<,>)
         }
 
         bool PropertyChosen => propertyName != null;

--- a/Assets/Scripts/Incidents/IncidentEditorWindow.cs
+++ b/Assets/Scripts/Incidents/IncidentEditorWindow.cs
@@ -159,8 +159,9 @@ namespace Game.Incidents
 
         public void UpdateActionFieldIDs()
 		{
-            var fieldCount = 0;
+            var fieldCount = 1;
             actionFields.Clear();
+            actionFields.Add(new ConstantActionField(ContextType));
 
             foreach (var a in actions)
 			{

--- a/Assets/Scripts/Incidents/IncidentEditorWindow.cs
+++ b/Assets/Scripts/Incidents/IncidentEditorWindow.cs
@@ -84,6 +84,7 @@ namespace Game.Incidents
 
             var loadedIncident = JsonConvert.DeserializeObject<Incident>(file, SaveUtilities.SERIALIZER_SETTINGS);
             incidentContextType = loadedIncident.ContextType;
+            ContextType = incidentContextType;
             incidentName = savedIncidentName;
             weight = loadedIncident.Weight;
             incidentLog = loadedIncident.Actions.incidentLog;
@@ -91,6 +92,7 @@ namespace Game.Incidents
             actions = new List<ActionChoiceContainer>();
             loadedIncident.Actions.Actions.ForEach(x => actions.Add(new ActionChoiceContainer(x, UpdateActionFieldIDs)));
             contextDeployers = loadedIncident.Actions.Deployers;
+            UpdateActionFieldIDs();
             modeChosen = true;
 
             OutputLogger.Log("Incident Loaded!");

--- a/Assets/Scripts/Incidents/LearnAboutReflection.cs
+++ b/Assets/Scripts/Incidents/LearnAboutReflection.cs
@@ -4,6 +4,5 @@ namespace Game.Incidents
 {
 	public class LearnAboutReflection : MonoBehaviour
 	{
-
 	}
 }

--- a/Assets/Scripts/JarvisMarchConvexHullReference.cs
+++ b/Assets/Scripts/JarvisMarchConvexHullReference.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
-using Game.Math;
+using Game.GameMath;
 
 public class JarvisMarchConvexHullReference : MonoBehaviour
 {

--- a/Assets/Scripts/Math/Polygon.cs
+++ b/Assets/Scripts/Math/Polygon.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 using System.Drawing;
 
-namespace Game.Math
+namespace Game.GameMath
 {
 	public class Polygon
     {

--- a/Assets/Scripts/Math/SpacialMath.cs
+++ b/Assets/Scripts/Math/SpacialMath.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 
-namespace Game.Math
+namespace Game.GameMath
 {
 	public static class SpacialMath
     {

--- a/Assets/Scripts/Simulation/SimulationManager.cs
+++ b/Assets/Scripts/Simulation/SimulationManager.cs
@@ -66,5 +66,13 @@ namespace Game.Simulation
 			SaveUtilities.LoadHexMapData(HexGrid, SaveUtilities.GetHexMapData(mapName));
 			world = World.Load(HexGrid, mapName);
 		}
+
+		public void DebugRun()
+		{
+			for(int i = 0; i < 100; i++)
+			{
+				world.AdvanceTime();
+			}
+		}
 	}
 }

--- a/Assets/Scripts/Simulation/SimulationManager.cs
+++ b/Assets/Scripts/Simulation/SimulationManager.cs
@@ -14,6 +14,8 @@ namespace Game.Simulation
 		public int WorldChunksX { get; set; }
 		public int WorldChunksZ { get; set; }
 
+		public World world;
+
 		private static SimulationManager instance;
 		public static SimulationManager Instance
 		{
@@ -32,7 +34,6 @@ namespace Game.Simulation
 			OutputLogger.Log("Sim Manager Made!");
 		}
 
-		public World world;
 
 		public ContextTypeListDictionary<IIncidentContextProvider> Providers => world.Providers;
 
@@ -40,6 +41,7 @@ namespace Game.Simulation
 		{
 			MapGenerator.GenerateMap(WorldChunksX * HexMetrics.chunkSizeX, WorldChunksZ * HexMetrics.chunkSizeZ);
 			world = new World(HexGrid);
+			world.Initialize();
 		}
 
 		public void CreateDebugWorld()

--- a/Assets/Scripts/Simulation/SimulationUtilities.cs
+++ b/Assets/Scripts/Simulation/SimulationUtilities.cs
@@ -1,0 +1,56 @@
+﻿using Game.Factions;
+using Game.Incidents;
+using Game.Terrain;
+using System.Collections.Generic;
+
+namespace Game.Simulation
+{
+	public static class SimulationUtilities
+	{
+		public static int GetRandomCellIndex()
+		{
+			return GetRandomCell().Index;
+		}
+
+		public static bool GetRandomUnclaimedCellIndex(out int index)
+		{
+			var found = false;
+			var cellIndex = 0;
+			index = -1;
+
+			for (int i = 0; i < 250 && !found; i++)
+			{
+				cellIndex = GetRandomCellIndex();
+				found = IsCellIndexUnclaimed(cellIndex);
+			}
+
+			if(found)
+			{
+				index = cellIndex;
+			}
+
+			return found;
+		}
+
+		public static bool IsCellIndexUnclaimed(int index)
+		{
+			foreach (var faction in SimulationManager.Instance.world.Providers[typeof(FactionContext)])
+			{
+				var context = faction.GetContext() as FactionContext;
+				if (context.controlledTileIndices.Contains(index))
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		private static HexCell GetRandomCell()
+		{
+			var grid = SimulationManager.Instance.HexGrid;
+			var numCells = grid.cellCountX * grid.cellCountZ;
+			return grid.GetCell(SimRandom.RandomRange(0, numCells));
+		}
+	}
+}

--- a/Assets/Scripts/Simulation/SimulationUtilities.cs.meta
+++ b/Assets/Scripts/Simulation/SimulationUtilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37dc8802e7234f44698b564df2146dfb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Simulation/World.cs
+++ b/Assets/Scripts/Simulation/World.cs
@@ -29,6 +29,18 @@ namespace Game.Simulation
 			CreateFactions(1);
 		}
 
+		public void AdvanceTime()
+		{
+			foreach(var providerList in Providers.Values)
+			{
+				foreach(var provider in providerList)
+				{
+					provider.UpdateContext();
+					provider.DeployContext();
+				}
+			}
+		}
+
 		public void Save(string mapName)
 		{
 

--- a/Assets/Scripts/Simulation/World.cs
+++ b/Assets/Scripts/Simulation/World.cs
@@ -22,7 +22,10 @@ namespace Game.Simulation
 		{
 			this.hexGrid = hexGrid;
 			Providers = new ContextTypeListDictionary<IIncidentContextProvider>();
+		}
 
+		public void Initialize()
+		{
 			CreateFactions(1);
 		}
 
@@ -43,7 +46,9 @@ namespace Game.Simulation
 		{
 			for(int i = 0; i < numFactions; i++)
 			{
-				Providers[typeof(FactionContext)].Add(new Faction());
+				var faction = new Faction();
+				Providers[typeof(FactionContext)].Add(faction);
+				faction.AttemptExpandBorder(1);
 			}
 		}
 	}

--- a/Assets/Scripts/Visuals/World/HexMap/Scripts/Bezier.cs
+++ b/Assets/Scripts/Visuals/World/HexMap/Scripts/Bezier.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace Game.Math
+namespace Game.GameMath
 {
 	public static class Bezier
 	{

--- a/Assets/Scripts/Visuals/World/HexMap/Scripts/HexGrid.cs
+++ b/Assets/Scripts/Visuals/World/HexMap/Scripts/HexGrid.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 using System.IO;
 using System.Collections.Generic;
 using Game.Collections;
+using System.Linq;
 
 namespace Game.Terrain
 {
@@ -57,6 +58,14 @@ namespace Game.Terrain
 			cellShaderData = gameObject.AddComponent<HexCellShaderData>();
 			cellShaderData.Grid = this;
 			//CreateMap(cellCountX, cellCountZ);
+		}
+
+		public void ResetSearchPhases()
+		{
+			foreach(var cell in cells)
+			{
+				cell.SearchPhase = 0;
+			}
 		}
 
 		public void AddUnit(HexUnit unit, HexCell location, float orientation)

--- a/Assets/Scripts/Visuals/World/HexMap/Scripts/HexUnit.cs
+++ b/Assets/Scripts/Visuals/World/HexMap/Scripts/HexUnit.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using Game.Collections;
-using Game.Math;
+using Game.GameMath;
 
 namespace Game.Terrain
 {


### PR DESCRIPTION
The original intent of this ticket was to test to ensure that in a simulation, the incident service would work through its flow entirely and run incident as intended. I wanted to cover all of the bases including criteria, action fields, logs, and deployment. I still need to go back and test logs, but everything else seemed to work just fine - I can now send faction contexts to the service and it will expand their borders once their influence hits certain thresholds. 

But in the process of working on this I discovered a bunch of oversights in functionality that I wanted to address, so this PR became much more about upgrading the service to be able to handle more use cases.

1) I wanted the context deployment to be able to pull context information from the rest of the incident. This means we can now grab fields that are calculated by the `IncidentContextActionField`s as well as the context that spawned the incident, and use any of that information in sending the next context.
2) I also wanted the deploy context step to be able to have variables that determined whether or not to deploy the next context. This could be based on simple random chance, or even based on variables generated or included in the other contexts, similar to what's discussed above. In short, now the deployment can check the variables of the original context or the ones generated by the actions to determine whether or not to fire off another context. This functionality is encompassed within the deployment criteria. 
3) I wanted to make the process of verifying context info and updating the editor automatic, so I dont have to manually new fields in each `IncidentAction` I make. This means a little extra reflection, which is unfortunate at run time, but it means for now, I can churn out incident actions without having to manually hook everything up. Perhaps I can find a more performant method in future if the need arises. 
4) Oh yeah, and expressions and criteria can now check properties against other properties. This is huge because it moves us away from having to have a bunch of static helper methods to grab and calculate info. Now expressions can just handle it like they handle everything else. 
5) Last minute addition: I added the criteria option of checking whether or not at least one value in a dictionary meets the expression criteria. So say, if you wanted to see if a faction was upset with another faction enough to start a war, you could store that as a `Dictionary<IIncidentContext, int>` and check to make sure at least one value was above, say, 100. I also added the ability to check collection lengths so you could say check that number of cities exceeded a certain amount and so on. Hopefully can discover a way to make these able to handle more generic data structures but this will serve my use cases for now.

For next steps I'm planning to look into whether we could merge `IIncidentContext` and `IIncidentContextProvider` as really a Faction, for example, IS its context so it might as well just pass itself if possible. Better to get this out of the way before I scale up, if possible.