### PR TITLE
11-04-2022 Create Person Action

### DIFF
--- a/Assets/Scripts/Data/IntegerRange.cs
+++ b/Assets/Scripts/Data/IntegerRange.cs
@@ -1,0 +1,29 @@
+﻿using Sirenix.OdinInspector;
+
+namespace Game.Incidents
+{
+	[HideReferenceObjectPicker, InlineProperty]
+	public class IntegerRange
+	{
+		[HorizontalGroup("A", LabelWidth = 52, Width = 40)]
+		public bool randomRange = true;
+
+		[ShowIf("@this.randomRange"), HorizontalGroup("A", Width = 30)]
+		public int min = 0, max = 20;
+		[HideIf("@this.randomRange"), HorizontalGroup("A", Width = 30)]
+		public int constant;
+
+		public static implicit operator int(IntegerRange i) => i.Value;
+		public int Value
+		{
+			get
+			{
+				return randomRange ? Calculate() : constant;
+			}
+		}
+		private int Calculate()
+		{
+			return SimRandom.RandomRange(min, max);
+		}
+	}
+}

--- a/Assets/Scripts/Data/IntegerRange.cs.meta
+++ b/Assets/Scripts/Data/IntegerRange.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a63a6a8980bed474a8746fb7ef6fca11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/TypeListDictionary.cs.meta
+++ b/Assets/Scripts/Data/TypeListDictionary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf024c329ec2ef4488129ef9e817c2f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generators/Items/Item.cs
+++ b/Assets/Scripts/Generators/Items/Item.cs
@@ -1,12 +1,16 @@
 ﻿using Game.Enums;
+using Game.Incidents;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
 namespace Game.Generators.Items
 {
-	public class Item
+	public class Item : InertIncidentContext
 	{
 		public virtual string Name => name;
+
+		public override Type ContextType => typeof(Item);
 
 		protected string name;
 		protected Material material;

--- a/Assets/Scripts/Incidents/ActionResultField.cs
+++ b/Assets/Scripts/Incidents/ActionResultField.cs
@@ -1,0 +1,33 @@
+﻿using Sirenix.OdinInspector;
+using System;
+using UnityEngine;
+
+namespace Game.Incidents
+{
+	[Serializable, HideReferenceObjectPicker]
+	public class ActionResultField<T> : ContextualIncidentActionField<T> where T : IIncidentContext
+	{
+		protected override bool ShowMethodChoice => false;
+		//protected override bool ShowAllowSelf => false;
+		[ReadOnly]
+		public override ActionFieldRetrievalMethod Method => ActionFieldRetrievalMethod.Random;
+		public ActionResultField(Type parentType) : base(parentType)
+		{
+			this.parentType = parentType;
+		}
+		public override IIncidentContext GetFieldValue()
+		{
+			return value;
+		}
+
+		public override bool CalculateField(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
+		{
+			return true;
+		}
+
+		public void SetValue(IIncidentContext context)
+		{
+			value = context;
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/ActionResultField.cs
+++ b/Assets/Scripts/Incidents/ActionResultField.cs
@@ -8,7 +8,7 @@ namespace Game.Incidents
 	public class ActionResultField<T> : ContextualIncidentActionField<T> where T : IIncidentContext
 	{
 		protected override bool ShowMethodChoice => false;
-		//protected override bool ShowAllowSelf => false;
+
 		[ReadOnly]
 		public override ActionFieldRetrievalMethod Method => ActionFieldRetrievalMethod.Random;
 		public ActionResultField(Type parentType) : base(parentType)
@@ -18,6 +18,11 @@ namespace Game.Incidents
 		public override IIncidentContext GetFieldValue()
 		{
 			return value;
+		}
+
+		public override T GetTypedFieldValue()
+		{
+			return (T)value;
 		}
 
 		public override bool CalculateField(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)

--- a/Assets/Scripts/Incidents/ActionResultField.cs.meta
+++ b/Assets/Scripts/Incidents/ActionResultField.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1e25f9779ba3854ab59dbb11524be15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Contexts/Person.cs
+++ b/Assets/Scripts/Incidents/Contexts/Person.cs
@@ -8,6 +8,31 @@ namespace Game.Incidents
 {
 	public class Person : IIncidentContext
 	{
+		public Person() { }
+		public Person(int age, Gender gender, Race race, Faction faction, int politicalPriority, int economicPriority,
+			int religiousPriority, int militaryPriority, int influence, int wealth, int strength, int dexterity,
+			int constitution, int intelligence, int wisdom, int charisma, List<Item> inventory = null, List<Person> parents = null)
+		{
+			Age = age;
+			Race = race;
+			Gender = gender == Gender.ANY ? (Gender)(SimRandom.RandomRange(0, 2)) : gender;
+			Faction = faction;
+			PoliticalPriority = politicalPriority;
+			EconomicPriority = economicPriority;
+			ReligiousPriority = religiousPriority;
+			MilitaryPriority = militaryPriority;
+			Influence = influence;
+			Wealth = wealth;
+			Strength = strength;
+			Dexterity = dexterity;
+			Constitution = constitution;
+			Intelligence = intelligence;
+			Wisdom = wisdom;
+			Charisma = charisma;
+			Inventory = inventory == null ? new List<Item>() : inventory;
+			Parents = parents == null ? new List<Person>() : parents;
+		}
+
 		public Type ContextType => typeof(Person);
 
 		public int NumIncidents { get; set; }
@@ -16,6 +41,7 @@ namespace Game.Incidents
 		public int Age { get; set; }
 		public Gender Gender { get; set; }
 		public Race Race { get; set; }
+		public Faction Faction { get; set; }
 		public int PoliticalPriority { get; set; }
 		public int EconomicPriority { get; set; }
 		public int ReligiousPriority { get; set; }
@@ -42,6 +68,4 @@ namespace Game.Incidents
 			
 		}
 	}
-
-	public class Race { }
 }

--- a/Assets/Scripts/Incidents/Contexts/Race.cs
+++ b/Assets/Scripts/Incidents/Contexts/Race.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Game.Incidents
+{
+	public class Race : InertIncidentContext
+	{
+		public override Type ContextType => typeof(Race);
+	}
+}

--- a/Assets/Scripts/Incidents/Contexts/Race.cs.meta
+++ b/Assets/Scripts/Incidents/Contexts/Race.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef18abf77d82dbc45a1f90923fbc7489
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Contexts/World.cs
+++ b/Assets/Scripts/Incidents/Contexts/World.cs
@@ -69,6 +69,11 @@ namespace Game.Simulation
 			return world;
 		}
 
+		public void AddContext<T>(T context) where T : IIncidentContext
+		{
+			Contexts[typeof(T)].Add(context);
+		}
+
 		private void CreateFactions(int numFactions)
 		{
 			for(int i = 0; i < numFactions; i++)

--- a/Assets/Scripts/Incidents/ContextualIncidentActionField.cs
+++ b/Assets/Scripts/Incidents/ContextualIncidentActionField.cs
@@ -15,10 +15,10 @@ namespace Game.Incidents
 		[HideInInspector]
 		public Type parentType;
 
-		[OnValueChanged("RetrievalTypeChanged"), ShowInInspector, PropertyOrder(-1)]
+		[OnValueChanged("RetrievalTypeChanged"), ShowIf("@this.ShowMethodChoice"), PropertyOrder(-1)]
 		virtual public ActionFieldRetrievalMethod Method { get; set; }
 
-		[ShowIf("@this.ParentTypeMatches"), HideIf("@this.Method == ActionFieldRetrievalMethod.From_Previous")]
+		[ShowIf("@this.ShowAllowSelf")]
 		public bool AllowSelf;
 
 		[ShowIf("Method", ActionFieldRetrievalMethod.Criteria), ListDrawerSettings(CustomAddFunction = "AddNewCriteriaItem"), HideReferenceObjectPicker]
@@ -39,20 +39,22 @@ namespace Game.Incidents
 
 		public Type ContextType => typeof(T);
 		private bool ParentTypeMatches => parentType == typeof(T);
+		virtual protected bool ShowMethodChoice => true;
+		virtual protected bool ShowAllowSelf => ParentTypeMatches && ShowMethodChoice && Method != ActionFieldRetrievalMethod.From_Previous;
 
-		private IIncidentContext value;
+		protected IIncidentContext value;
 		private IIncidentActionField delayedValue;
 
 		public ContextualIncidentActionField() 
 		{
 			RetrievalTypeChanged();
 		}
-		public ContextualIncidentActionField(Type parentType) : base()
+		public ContextualIncidentActionField(Type parentType) : this()
 		{
 			this.parentType = parentType;
 		}
 
-		public IIncidentContext GetFieldValue()
+		virtual public IIncidentContext GetFieldValue()
 		{
 			if (Method == ActionFieldRetrievalMethod.From_Previous)
 			{
@@ -64,7 +66,7 @@ namespace Game.Incidents
 			}
 		}
 
-		public bool CalculateField(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
+		virtual public bool CalculateField(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
 		{
 			if(Method == ActionFieldRetrievalMethod.Criteria)
 			{

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/CreatePersonAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/CreatePersonAction.cs
@@ -1,0 +1,38 @@
+﻿using Game.Enums;
+using Game.Simulation;
+using System;
+using System.Collections.Generic;
+
+namespace Game.Incidents
+{
+	public class CreatePersonAction : GenericIncidentAction
+	{
+		public ContextualIncidentActionField<Person> parent;
+		public ContextualIncidentActionField<Race> race;
+		public ContextualIncidentActionField<Faction> faction;
+		public Gender gender;
+		public IntegerRange age;
+		public IntegerRange politicalPriority;
+		public IntegerRange economicPriority;
+		public IntegerRange religiousPriority;
+		public IntegerRange militaryPriority;
+		public IntegerRange influence;
+		public IntegerRange wealth;
+		public IntegerRange strength;
+		public IntegerRange dexterity;
+		public IntegerRange constitution;
+		public IntegerRange intelligence;
+		public IntegerRange wisdom;
+		public IntegerRange charisma;
+		public ActionResultField<Person> personResult;
+
+		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
+		{
+			var parents = parent.GetTypedFieldValue() != null ? new List<Person>() { parent.GetTypedFieldValue() } : null;
+			var person = new Person(age, gender, race.GetTypedFieldValue(), faction.GetTypedFieldValue(), politicalPriority,
+				economicPriority, religiousPriority, militaryPriority, influence, wealth, strength, dexterity, constitution,
+				intelligence, wisdom, charisma, null, parents);
+			SimulationManager.Instance.world.AddContext(person);
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/CreatePersonAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/CreatePersonAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e5b474dd1db78449834f898c3da4240
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetPersonFactionAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetPersonFactionAction.cs
@@ -1,0 +1,13 @@
+﻿namespace Game.Incidents
+{
+	public class GetPersonFactionAction : GenericIncidentAction
+	{
+		public ContextualIncidentActionField<Person> person;
+		public ActionResultField<Faction> faction;
+
+		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
+		{
+			faction.SetValue(person.GetTypedFieldValue().Faction);
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetPersonFactionAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetPersonFactionAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ea2a229118d298499cdbff484e98ac4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
@@ -32,7 +32,7 @@ namespace Game.Incidents
 
 			foreach (var field in matchingFields)
 			{
-				field.SetValue(this, Activator.CreateInstance(field.FieldType));
+				field.SetValue(this, Activator.CreateInstance(field.FieldType, IncidentEditorWindow.ContextType));
 			}
 		}
 
@@ -82,7 +82,8 @@ namespace Game.Incidents
 		private IEnumerable<FieldInfo> GetContexualActionFields()
 		{
 			var fields = this.GetType().GetFields();
-			return fields.Where(x => x.FieldType.IsGenericType && x.FieldType.GetGenericTypeDefinition() == typeof(ContextualIncidentActionField<>));
+			return fields.Where(x => x.FieldType.IsGenericType && (x.FieldType.GetGenericTypeDefinition() == typeof(ContextualIncidentActionField<>)
+			|| x.FieldType.GetGenericTypeDefinition() == typeof(ActionResultField<>)));
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
@@ -34,6 +34,13 @@ namespace Game.Incidents
 			{
 				field.SetValue(this, Activator.CreateInstance(field.FieldType, IncidentEditorWindow.ContextType));
 			}
+
+			matchingFields = GetIntegerRangeFields();
+
+			foreach (var field in matchingFields)
+			{
+				field.SetValue(this, Activator.CreateInstance(field.FieldType));
+			}
 		}
 
 		virtual public void UpdateActionFieldIDs(ref int startingValue)
@@ -84,6 +91,12 @@ namespace Game.Incidents
 			var fields = this.GetType().GetFields();
 			return fields.Where(x => x.FieldType.IsGenericType && (x.FieldType.GetGenericTypeDefinition() == typeof(ContextualIncidentActionField<>)
 			|| x.FieldType.GetGenericTypeDefinition() == typeof(ActionResultField<>)));
+		}
+
+		private IEnumerable<FieldInfo> GetIntegerRangeFields()
+		{
+			var fields = this.GetType().GetFields();
+			return fields.Where(x => x.FieldType == typeof(IntegerRange));
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentEditorWindow.cs
+++ b/Assets/Scripts/Incidents/IncidentEditorWindow.cs
@@ -118,7 +118,8 @@ namespace Game.Incidents
             var q = typeof(IIncidentContext).Assembly.GetTypes()
                 .Where(x => !x.IsAbstract)                                          // Excludes BaseClass
                 .Where(x => !x.IsGenericTypeDefinition)                             // Excludes C1<>
-                .Where(x => typeof(IIncidentContext).IsAssignableFrom(x));          // Excludes classes not inheriting from BaseClass
+                .Where(x => typeof(IIncidentContext).IsAssignableFrom(x))          // Excludes classes not inheriting from BaseClass
+                .Where(x => !typeof(InertIncidentContext).IsAssignableFrom(x));
 
             return q;
         }

--- a/Assets/Scripts/Incidents/InertIncidentContext.cs
+++ b/Assets/Scripts/Incidents/InertIncidentContext.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Game.Incidents
+{
+	public abstract class InertIncidentContext : IIncidentContext
+	{
+		abstract public Type ContextType { get; }
+
+		public int NumIncidents => 0;
+
+		public int ParentID => -1;
+
+		public void DeployContext()
+		{
+
+		}
+
+		public void UpdateContext()
+		{
+
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/InertIncidentContext.cs.meta
+++ b/Assets/Scripts/Incidents/InertIncidentContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36096d93c09198d449b81ecc02ce674a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR handles all of the stuff necessary to properly create a person in an incident action.

1. Added `IntegerRange` which allows you to define either a constant integer value or a range to randomly create an integer within, which can be used to semi randomize the stats of a person. This of course can be used other places too.
2. Added `GetPersonFactionAction` to easily get a person's faction without having to rework how `ContextualIncidentActionField` works. Might do a rework in future though to simplify this flow.
3. Created an `InertIncidentContext`, which serves as a way to mark certain things, such as Race and Items as contexts which can be stored and reference, but which don't update over time, and don't use the `IncidentService` directly.
4. Added `ActionFieldResult` which works as an `IncidentActionField` but stores the result of an action to be used by later actions.
5. Changed `ContextualIncidentActionField` to allow returning a null when its set to From_Previous. That way you can choose to not give it an ID and it should just return null, such as when you create a person from thin air and they don't have parents to go get contexts for.
6. Finally, created `CreatePersonAction` which brings all of this together, constructs a person, and adds them to the `World` context dictionary.