### PR TITLE
11-10-2022 Faction Create/Destroy Actions

### DIFF
--- a/Assets/Scripts/Incidents/Contexts/Faction.cs
+++ b/Assets/Scripts/Incidents/Contexts/Faction.cs
@@ -26,6 +26,9 @@ namespace Game.Incidents
 		public int EconomicPriority { get; set; }
 		public int ReligiousPriority { get; set; }
 		public int MilitaryPriority { get; set; }
+
+		virtual public bool CanExpandTerritory => true;
+		virtual public bool CanTakeMilitaryAction => true;
 		//Government structure related stuff goes here
 
 		[HideInInspector]
@@ -33,6 +36,7 @@ namespace Game.Incidents
 
 		public Faction()
 		{
+			Cities = new List<City>();
 		}
 
 		public Faction(int startingTiles)
@@ -40,9 +44,20 @@ namespace Game.Incidents
 			AttemptExpandBorder(startingTiles);
 		}
 
+		public Faction(int population, int influence, int wealth, int politicalPriority, int economicPriority, int religiousPriority, int militaryPriority) : this()
+		{
+			Population = population;
+			Influence = influence;
+			Wealth = wealth;
+			PoliticalPriority = politicalPriority;
+			EconomicPriority = economicPriority;
+			ReligiousPriority = religiousPriority;
+			MilitaryPriority = militaryPriority;
+		}
+
 		public void DeployContext()
 		{
-			IncidentService.Instance.PerformIncidents(this);
+			IncidentService.Instance.PerformIncidents((Faction)this);
 		}
 		public void UpdateContext()
 		{
@@ -51,6 +66,14 @@ namespace Game.Incidents
 			UpdateInfluence();
 			UpdatePERMS();
 			UpdateNumIncidents();
+		}
+
+		public void CreateStartingCity()
+		{
+			var cells = SimulationUtilities.GetCitylessCellsFromList(ControlledTileIndices);
+			var city = new City(this, new Location(SimRandom.RandomEntryFromList(cells)), 10, 0);
+			Cities.Add(city);
+			SimulationManager.Instance.world.AddContext(city);
 		}
 
 		public bool AttemptExpandBorder(int numTimes)

--- a/Assets/Scripts/Incidents/Contexts/Special Factions.meta
+++ b/Assets/Scripts/Incidents/Contexts/Special Factions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d04cb5b457bd7944b5ffa98c953c40d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Contexts/Special Factions/MagicAcademy.cs
+++ b/Assets/Scripts/Incidents/Contexts/Special Factions/MagicAcademy.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Game.Incidents
+{
+	public class MagicAcademy : SpecialFaction
+	{
+		public override bool CanExpandTerritory => false;
+		public override bool CanTakeMilitaryAction => false;
+	}
+}

--- a/Assets/Scripts/Incidents/Contexts/Special Factions/MagicAcademy.cs.meta
+++ b/Assets/Scripts/Incidents/Contexts/Special Factions/MagicAcademy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cc1eec75f56b25429509af70b1ce873
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Contexts/Special Factions/SpecialFaction.cs
+++ b/Assets/Scripts/Incidents/Contexts/Special Factions/SpecialFaction.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Game.Incidents
+{
+	abstract public class SpecialFaction : Faction
+	{
+		private static List<SpecialFactionBiasContainer> FactionTypes = new List<SpecialFactionBiasContainer>
+		{
+			{ new SpecialFactionBiasContainer(12, 10, 0, 0, typeof(MagicAcademy)) }
+		};
+
+		public static Type CalculateFactionType(int political, int economic, int religious, int military)
+		{
+			var container = FactionTypes[0];
+			var previousBest = CalculateScores(container, political, economic, religious, military);
+			for (int i = 1; i < FactionTypes.Count; i++)
+			{
+				var total = CalculateScores(FactionTypes[i], political, economic, religious, military);
+				if(total < previousBest)
+				{
+					container = FactionTypes[i];
+				}
+			}
+			return container.factionType;
+		}
+
+		private static int CalculateScores(SpecialFactionBiasContainer container, int political, int economic, int religious, int military)
+		{
+			return CalculateScore(political, container.politicalBias) +
+					CalculateScore(economic, container.economicBias) +
+					CalculateScore(religious, container.religiousBias) +
+					CalculateScore(military, container.militaryBias);
+		}
+
+		private static int CalculateScore(int input, int fromDictionary)
+		{
+			var difference = fromDictionary - input;
+			if(difference > 0)
+			{
+				difference *= 3;
+			}
+			else if(difference < 0)
+			{
+				difference = Math.Abs(difference);
+			}
+			return difference;
+		}
+	}
+
+	public struct SpecialFactionBiasContainer
+	{
+		public int politicalBias;
+		public int economicBias;
+		public int religiousBias;
+		public int militaryBias;
+		public Type factionType;
+
+		public SpecialFactionBiasContainer(int politicalBias, int economicBias, int religiousBias, int militaryBias, Type factionType)
+		{
+			this.politicalBias = politicalBias;
+			this.economicBias = economicBias;
+			this.religiousBias = religiousBias;
+			this.militaryBias = militaryBias;
+			this.factionType = factionType;
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/Contexts/Special Factions/SpecialFaction.cs.meta
+++ b/Assets/Scripts/Incidents/Contexts/Special Factions/SpecialFaction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba8e27f71e29e364caea0edb92c80fd1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/CreateCityAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/CreateCityAction.cs
@@ -1,5 +1,4 @@
 ﻿using Game.Simulation;
-using System;
 
 namespace Game.Incidents
 {
@@ -13,6 +12,7 @@ namespace Game.Incidents
 		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
 		{
 			var city = new City(faction.GetTypedFieldValue(), location.GetTypedFieldValue(), population, wealth);
+			faction.GetTypedFieldValue().Cities.Add(city);
 			SimulationManager.Instance.world.AddContext(city);
 			resultCity.SetValue(city);
 			OutputLogger.Log("City created!");

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/CreateFactionAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/CreateFactionAction.cs
@@ -1,0 +1,26 @@
+﻿using Game.Simulation;
+
+namespace Game.Incidents
+{
+	public class CreateFactionAction : GenericIncidentAction
+	{
+        public ActionResultField<Faction> factionResult;
+
+        public IntegerRange population;
+        public IntegerRange influence;
+        public IntegerRange wealth;
+        public IntegerRange politicalPriority;
+        public IntegerRange economicPriority;
+        public IntegerRange religiousPriority;
+        public IntegerRange militaryPriority;
+
+        public override void PerformAction(IIncidentContext context, ref IncidentReport report)
+		{
+            var faction = new Faction(population, influence, wealth, politicalPriority, economicPriority, religiousPriority, militaryPriority);
+            faction.AttemptExpandBorder(1);
+            faction.CreateStartingCity();
+            factionResult.SetValue(faction);
+            SimulationManager.Instance.world.AddContext(faction);
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/CreateFactionAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/CreateFactionAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8f3e9498560e484791d53098ec2bbf3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/CreateSpecialFactionAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/CreateSpecialFactionAction.cs
@@ -1,0 +1,36 @@
+﻿using Game.Simulation;
+using Sirenix.OdinInspector;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Incidents
+{
+	public class CreateSpecialFactionAction : CreateFactionAction
+	{
+        public override void PerformAction(IIncidentContext context, ref IncidentReport report)
+        {
+            var specialFactionType = SpecialFaction.CalculateFactionType(politicalPriority, economicPriority, religiousPriority, militaryPriority);
+            var specialFaction = (Faction)Activator.CreateInstance(specialFactionType);
+            specialFaction.Population = population;
+            specialFaction.Influence = influence;
+            specialFaction.Wealth = wealth;
+            specialFaction.PoliticalPriority = politicalPriority;
+            specialFaction.EconomicPriority = economicPriority;
+            specialFaction.ReligiousPriority = religiousPriority;
+            specialFaction.MilitaryPriority = militaryPriority;
+
+            SimulationManager.Instance.world.AddContext<Faction>(specialFaction);
+        }
+
+        private IEnumerable<Type> GetFilteredTypeList()
+        {
+            var q = typeof(SpecialFaction).Assembly.GetTypes()
+                .Where(x => !x.IsAbstract)
+                .Where(x => !x.IsGenericTypeDefinition)
+                .Where(x => typeof(SpecialFaction).IsAssignableFrom(x));
+
+            return q;
+        }
+    }
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/CreateSpecialFactionAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/CreateSpecialFactionAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8e46e4c78e2112409a73ff0b14ed1e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyFactionAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyFactionAction.cs
@@ -1,0 +1,14 @@
+﻿using Game.Simulation;
+
+namespace Game.Incidents
+{
+	public class DestroyFactionAction : GenericIncidentAction
+	{
+        public ContextualIncidentActionField<Faction> faction;
+
+		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
+		{
+            SimulationManager.Instance.world.RemoveContext(faction.GetTypedFieldValue());
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyFactionAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyFactionAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 259d7aaa63d933b41b7578360eebf762
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentEditorWindow.cs
+++ b/Assets/Scripts/Incidents/IncidentEditorWindow.cs
@@ -117,9 +117,10 @@ namespace Game.Incidents
         {
             var q = typeof(IIncidentContext).Assembly.GetTypes()
                 .Where(x => !x.IsAbstract)                                          // Excludes BaseClass
-                .Where(x => !x.IsGenericTypeDefinition)                             // Excludes C1<>
-                .Where(x => typeof(IIncidentContext).IsAssignableFrom(x))          // Excludes classes not inheriting from BaseClass
-                .Where(x => !typeof(InertIncidentContext).IsAssignableFrom(x));
+                .Where(x => !x.IsGenericTypeDefinition)                             // Excludes Generics
+                .Where(x => typeof(IIncidentContext).IsAssignableFrom(x))           // Excludes classes not inheriting from IIncidentContext
+                .Where(x => !typeof(InertIncidentContext).IsAssignableFrom(x))      // Excludes inert contexts
+                .Where(x => x.BaseType != typeof(SpecialFaction));                  // Excludes special factions for now
 
             return q;
         }


### PR DESCRIPTION
Added basic actions for creating factions based on params, as well as destroying a faction based on a contextual action field.
After some discussion, it was decided we needed to designate certain factions as special factions, with criteria that can be overridden to prevent certain actions from being taken. So for example, any faction that should never expand can set the new `CanExpandTerritory` property to false, allowing the incident system to skip over any expansion related incidents for that context.
Any of these special faction will inherit from `SpecialFaction` and will need to designate the things they are overriding on a case by case basis.