### PR TITLE
11-11-2022 Get Contexts Action (and some misc friends)

### DIFF
--- a/Assets/Scripts/Generators/Items/Armor.cs
+++ b/Assets/Scripts/Generators/Items/Armor.cs
@@ -3,10 +3,14 @@ using UnityEngine;
 
 namespace Game.Generators.Items
 {
-	public class Armor : MonoBehaviour
+	public class Armor : Item, IEquipable
 	{
 		public ArmorType type;
 		public int flatBonus;
 		public ItemGrade itemGrade;
+
+		public Armor()
+		{
+		}
 	}
 }

--- a/Assets/Scripts/Generators/Items/Item.cs
+++ b/Assets/Scripts/Generators/Items/Item.cs
@@ -6,33 +6,9 @@ using System.Reflection;
 
 namespace Game.Generators.Items
 {
-	public class Item : InertIncidentContext
+	abstract public class Item : InertIncidentContext
 	{
-		public virtual string Name => name;
-
 		public override Type ContextType => typeof(Item);
-
-		protected string name;
-		protected Material material;
-
-		public List<MethodInfo> simulationEffects;
-		public List<string> gameEffects;
-
-		public Item(string name, Material material, List<MethodInfo> simulationEffects, List<string> gameEffects)
-		{
-			this.name = name;
-			this.material = material;
-			this.simulationEffects = simulationEffects;
-			this.gameEffects = gameEffects;
-		}
-
-		public void Activate()
-		{
-			foreach (var method in simulationEffects)
-			{
-				method.Invoke(null, new object[] { });
-			}
-		}
 	}
 
 	[System.Serializable]

--- a/Assets/Scripts/Generators/Items/Trinket.cs
+++ b/Assets/Scripts/Generators/Items/Trinket.cs
@@ -1,0 +1,10 @@
+﻿namespace Game.Generators.Items
+{
+	public class Trinket : Item, IEquipable
+	{
+		public Trinket()
+		{
+
+		}
+	}
+}

--- a/Assets/Scripts/Generators/Items/Trinket.cs.meta
+++ b/Assets/Scripts/Generators/Items/Trinket.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 774490e4c649b024b9f9861f1acb2b4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generators/Items/Weapon.cs
+++ b/Assets/Scripts/Generators/Items/Weapon.cs
@@ -10,23 +10,8 @@ namespace Game.Generators.Items
 		public int flatBonus;
 		public ItemGrade itemGrade;
 
-		public Weapon(string name, Material material, WeaponType baseStats, int flatBonus, ItemGrade itemGrade, List<string> gameEffects, List<MethodInfo> simulationEffects) : base (name, material, simulationEffects, gameEffects)
+		public Weapon()
 		{
-			this.type = baseStats;
-			this.flatBonus = flatBonus;
-			this.itemGrade = itemGrade;
-		}
-
-		public override string Name => GetWeaponName();
-
-		private string GetWeaponName()
-		{
-			var weaponName = name;
-			if(flatBonus > 0)
-			{
-				weaponName = string.Format("+{0} {1}", flatBonus, name);
-			}
-			return weaponName;
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/Contexts/Faction.cs
+++ b/Assets/Scripts/Incidents/Contexts/Faction.cs
@@ -26,7 +26,9 @@ namespace Game.Incidents
 		public int EconomicPriority { get; set; }
 		public int ReligiousPriority { get; set; }
 		public int MilitaryPriority { get; set; }
+		public List<Faction> FactionsAtWarWith { get; set; }
 
+		public bool AtWar => FactionsAtWarWith.Count > 0;
 		virtual public bool CanExpandTerritory => true;
 		virtual public bool CanTakeMilitaryAction => true;
 		//Government structure related stuff goes here
@@ -37,6 +39,7 @@ namespace Game.Incidents
 		public Faction()
 		{
 			Cities = new List<City>();
+			FactionsAtWarWith = new List<Faction>();
 		}
 
 		public Faction(int startingTiles)

--- a/Assets/Scripts/Incidents/IncidentActions/ActionFields/IncidentActionFieldContainer.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/ActionFields/IncidentActionFieldContainer.cs
@@ -1,0 +1,34 @@
+﻿using Sirenix.OdinInspector;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Incidents
+{
+	public class IncidentActionFieldContainer
+	{
+		[ValueDropdown("GetFilteredTypeList"), OnValueChanged("SetContextType"), LabelText("Context Type")]
+		public Type contextType;
+		[ShowIf("@this.actionField != null")]
+		public IIncidentActionField actionField;
+
+		private void SetContextType()
+		{
+			var dataType = new Type[] { contextType };
+			var genericBase = typeof(ContextualIncidentActionField<>);
+			var combinedType = genericBase.MakeGenericType(dataType);
+			actionField = (IIncidentActionField)Activator.CreateInstance(combinedType);
+			IncidentEditorWindow.UpdateActionFieldIDs();
+		}
+		private IEnumerable<Type> GetFilteredTypeList()
+		{
+			var q = typeof(IIncidentContext).Assembly.GetTypes()
+				.Where(x => !x.IsAbstract)                                          // Excludes BaseClass
+				.Where(x => !x.IsGenericTypeDefinition)                             // Excludes Generics
+				.Where(x => typeof(IIncidentContext).IsAssignableFrom(x))           // Excludes classes not inheriting from IIncidentContext
+				.Where(x => x.BaseType != typeof(SpecialFaction));                  // Excludes special factions for now
+
+			return q;
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/ActionFields/IncidentActionFieldContainer.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/ActionFields/IncidentActionFieldContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4fead22fede777843ae614133692690e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeControlOfTerritoryAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeControlOfTerritoryAction.cs
@@ -1,0 +1,27 @@
+﻿namespace Game.Incidents
+{
+	public class ChangeControlOfTerritoryAction : GenericIncidentAction
+	{
+		public ContextualIncidentActionField<Faction> territoryGainer;
+		public ContextualIncidentActionField<Faction> territoryLoser;
+		public LocationActionField location;
+
+		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
+		{
+			var gainer = territoryGainer.GetTypedFieldValue();
+			var loser = territoryLoser.GetTypedFieldValue();
+			var tileIndex = location.GetTypedFieldValue().TileIndex;
+
+			if (!gainer.ControlledTileIndices.Contains(tileIndex))
+			{
+				gainer.ControlledTileIndices.Add(tileIndex);
+			}
+			if(loser.ControlledTileIndices.Contains(tileIndex))
+			{
+				loser.ControlledTileIndices.Remove(tileIndex);
+			}
+
+			//Might need to notify tile inhabitants later so they can adjust for the change
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeControlOfTerritoryAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeControlOfTerritoryAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5c5b1d08b908054884195eab9e90f92
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeFactionRelationsAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeFactionRelationsAction.cs
@@ -1,0 +1,24 @@
+﻿namespace Game.Incidents
+{
+	public class ChangeFactionRelationsAction : GenericIncidentAction
+	{
+		public ContextualIncidentActionField<Faction> affectedFaction;
+		public ContextualIncidentActionField<Faction> otherFaction;
+		public IntegerRange amount;
+
+		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
+		{
+			var factionA = affectedFaction.GetTypedFieldValue();
+			var factionB = otherFaction.GetTypedFieldValue();
+			if(factionA != factionB)
+			{
+				if(!factionA.FactionRelations.ContainsKey(factionB))
+				{
+					factionA.FactionRelations.Add(factionB, 0);
+				}
+
+				factionA.FactionRelations[factionB] += amount.Value;
+			}
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeFactionRelationsAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeFactionRelationsAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77839777ccbe4814e9d284cccf822f69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeWarStateAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeWarStateAction.cs
@@ -1,0 +1,31 @@
+﻿namespace Game.Incidents
+{
+	public class ChangeWarStateAction : GenericIncidentAction
+	{
+		public ContextualIncidentActionField<Faction> factionOne;
+		public ContextualIncidentActionField<Faction> factionTwo;
+		public bool atWar;
+
+		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
+		{
+			var f1 = factionOne.GetTypedFieldValue();
+			var f2 = factionTwo.GetTypedFieldValue();
+			if(atWar)
+			{
+				f1.FactionsAtWarWith.Add(f2);
+				f2.FactionsAtWarWith.Add(f1);
+			}
+			else
+			{
+				if(f1.FactionsAtWarWith.Contains(f2))
+				{
+					f1.FactionsAtWarWith.Remove(f2);
+				}
+				if (f2.FactionsAtWarWith.Contains(f1))
+				{
+					f2.FactionsAtWarWith.Remove(f1);
+				}
+			}
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeWarStateAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeWarStateAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ac3182bfbae183488b26c8cf2a9e0f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/CreateItemAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/CreateItemAction.cs
@@ -1,0 +1,32 @@
+﻿using Game.Generators.Items;
+using Game.Simulation;
+using Sirenix.OdinInspector;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Incidents
+{
+	public class CreateItemAction : GenericIncidentAction
+	{
+		[ValueDropdown("GetFilteredTypeList")]
+		public Type itemType;
+		public ActionResultField<Item> resultItem;
+		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
+		{
+			var item = (Item)Activator.CreateInstance(itemType);
+			SimulationManager.Instance.world.AddContext(item);
+			resultItem.SetValue(item);
+		}
+
+		private IEnumerable<Type> GetFilteredTypeList()
+		{
+			var q = typeof(Item).Assembly.GetTypes()
+				.Where(x => !x.IsAbstract)                                          // Excludes BaseClass
+				.Where(x => !x.IsGenericTypeDefinition)                             // Excludes Generics
+				.Where(x => typeof(Item).IsAssignableFrom(x));
+
+			return q;
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/CreateItemAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/CreateItemAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8a0bff56c486884cb25c1e233dfb151
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetContextsAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetContextsAction.cs
@@ -1,0 +1,25 @@
+﻿using Sirenix.OdinInspector;
+using System.Collections.Generic;
+
+namespace Game.Incidents
+{
+	public class GetContextsAction : GenericIncidentAction
+	{
+		[ListDrawerSettings(CustomAddFunction = "AddNewActionFieldContainer", CustomRemoveIndexFunction = "OnRemoveIndex"), HideReferenceObjectPicker]
+		public List<IncidentActionFieldContainer> actionFields;
+		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
+		{
+		}
+
+		private void AddNewActionFieldContainer()
+		{
+			actionFields.Add(new IncidentActionFieldContainer());
+		}
+
+		private void OnRemoveIndex(int i)
+		{
+			actionFields.RemoveAt(i);
+			IncidentEditorWindow.UpdateActionFieldIDs();
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetContextsAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetContextsAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe43e487ade716a44bf672c3955e1b35
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
@@ -11,6 +11,7 @@ namespace Game.Incidents
 		virtual public bool VerifyAction(IIncidentContext context, Func<int, IIncidentActionField> delayedCalculateAction)
 		{
 			var matchingFields = GetContexualActionFields();
+			var matchingLists = GetCollectionsOfActionFields();
 
 			foreach (var field in matchingFields)
 			{
@@ -18,6 +19,18 @@ namespace Game.Incidents
 				if (!actionField.CalculateField(context, delayedCalculateAction))
 				{
 					return false;
+				}
+			}
+
+			foreach (var l in matchingLists)
+			{
+				var list = l.GetValue(this) as List<IncidentActionFieldContainer>;
+				foreach (var actionFieldContainer in list)
+				{
+					if (!actionFieldContainer.actionField.CalculateField(context, delayedCalculateAction))
+					{
+						return false;
+					}
 				}
 			}
 
@@ -35,6 +48,13 @@ namespace Game.Incidents
 				field.SetValue(this, Activator.CreateInstance(field.FieldType, IncidentEditorWindow.ContextType));
 			}
 
+			matchingFields = GetCollectionsOfActionFields();
+
+			foreach(var field in matchingFields)
+			{
+				field.SetValue(this, Activator.CreateInstance(field.FieldType));
+			}
+
 			matchingFields = GetIntegerRangeFields();
 
 			foreach (var field in matchingFields)
@@ -46,6 +66,7 @@ namespace Game.Incidents
 		virtual public void UpdateActionFieldIDs(ref int startingValue)
 		{
 			var matchingFields = GetContexualActionFields();
+			var matchingLists = GetCollectionsOfActionFields();
 
 			foreach (var f in matchingFields)
 			{
@@ -55,22 +76,46 @@ namespace Game.Incidents
 				IncidentEditorWindow.actionFields.Add(fa);
 				startingValue++;
 			}
+
+			foreach(var l in matchingLists)
+			{
+				var list = l.GetValue(this) as List<IncidentActionFieldContainer>;
+				foreach(var f in list)
+				{
+					f.actionField.ActionFieldID = startingValue;
+					f.actionField.NameID = string.Format("{0}:{1}:{2}", f.actionField.ActionFieldIDString, GetType().Name, l.Name);
+					IncidentEditorWindow.actionFields.Add(f.actionField);
+					startingValue++;
+				}
+			}
 		}
 
 		virtual public void AddContext(ref IncidentReport report)
 		{
 			var matchingFields = GetContexualActionFields();
+			var matchingLists = GetCollectionsOfActionFields();
 
 			foreach (var field in matchingFields)
 			{
 				var actionField = field.GetValue(this) as IIncidentActionField;
 				report.Contexts.Add(actionField.ActionFieldIDString, actionField.GetFieldValue());
 			}
+
+			foreach (var l in matchingLists)
+			{
+				var list = l.GetValue(this) as List<IncidentActionFieldContainer>;
+				foreach (var actionFieldContainer in list)
+				{
+					var actionField = actionFieldContainer.actionField;
+					report.Contexts.Add(actionField.ActionFieldIDString, actionField.GetFieldValue());
+				}
+			}
 		}
 
 		virtual public bool GetContextField(int id, out IIncidentActionField contextField)
 		{
 			var matchingFields = GetContexualActionFields();
+			var matchingLists = GetCollectionsOfActionFields();
 
 			foreach (var field in matchingFields)
 			{
@@ -79,6 +124,20 @@ namespace Game.Incidents
 				{
 					contextField = actionField;
 					return true;
+				}
+			}
+
+			foreach (var l in matchingLists)
+			{
+				var list = l.GetValue(this) as List<IncidentActionFieldContainer>;
+				foreach (var actionFieldContainer in list)
+				{
+					var actionField = actionFieldContainer.actionField;
+					if (actionField.ActionFieldID == id)
+					{
+						contextField = actionField;
+						return true;
+					}
 				}
 			}
 
@@ -91,6 +150,13 @@ namespace Game.Incidents
 			var fields = this.GetType().GetFields();
 			return fields.Where(x => (x.FieldType.IsGenericType && (x.FieldType.GetGenericTypeDefinition() == typeof(ContextualIncidentActionField<>)
 			|| x.FieldType.GetGenericTypeDefinition() == typeof(ActionResultField<>))) || x.FieldType == typeof(LocationActionField));
+		}
+
+		private IEnumerable<FieldInfo> GetCollectionsOfActionFields()
+		{
+			var fields = this.GetType().GetFields();
+			var lists = fields.Where(x => x.FieldType.IsGenericType && x.FieldType.GetGenericTypeDefinition() == typeof(List<>) && x.FieldType.GetGenericArguments()[0] == typeof(IncidentActionFieldContainer));
+			return lists;
 		}
 
 		private IEnumerable<FieldInfo> GetIntegerRangeFields()


### PR DESCRIPTION
The big winner for this PR is the `GetContextsAction`. It's only function is to get whatever contexts you might want, without having to know which types ahead of time, and it would be used for lists of action fields when you won't know exactly how many or what type of context you'll want. This way we can grab any contexts we want to use for a log only incident without needing other actions to grab them specifically. 

This required setting up a `IncidentActionFieldContainer` class that allow you to choose a context type, and it will use reflection to create a matching `ContextualIncidentActionField` for that type, then add it to the list. It also meant I needed to change every part of `IncidentAction` that dealt with grabbing all of it's contextual fields, and have it also search for lists of contextual fields. 

I also had a bunch of outstanding smaller actions that didn't feel like they each needed their own PR's. I will likely add more, but for now they include:
- Create Item
- Change Faction Relations
- Change War State
- Change Control of Territory