### PR TITLE
11-26-2022 More Incident Bugfixing

### DIFF
--- a/Assets/Resources/IncidentData/Faction Expand Territory Over Time.json
+++ b/Assets/Resources/IncidentData/Faction Expand Territory Over Time.json
@@ -2,7 +2,7 @@
   "$id": "1",
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 8,
+  "Weight": 17,
   "Criteria": {
     "$id": "2",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
@@ -36,7 +36,7 @@
                     "min": 0,
                     "max": 20,
                     "constant": 0,
-                    "Value": 13,
+                    "Value": 15,
                     "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
                   "rangeWarning": "Range not implemented for non integers!",
@@ -58,7 +58,7 @@
                     "min": 0,
                     "max": 20,
                     "constant": 0,
-                    "Value": 6,
+                    "Value": 1,
                     "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
                   "rangeWarning": "Range not implemented for non integers!",
@@ -148,7 +148,7 @@
                             "min": 0,
                             "max": 20,
                             "constant": 0,
-                            "Value": 2,
+                            "Value": 19,
                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                           },
                           "rangeWarning": "Range not implemented for non integers!",
@@ -170,7 +170,7 @@
                             "min": 0,
                             "max": 20,
                             "constant": 0,
-                            "Value": 0,
+                            "Value": 5,
                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                           },
                           "rangeWarning": "Range not implemented for non integers!",

--- a/Assets/Resources/IncidentData/Faction Expand Territory Over Time.json
+++ b/Assets/Resources/IncidentData/Faction Expand Territory Over Time.json
@@ -1,0 +1,201 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 8,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "3",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "Influence",
+          "evaluator": {
+            "$id": "4",
+            "$type": "Game.Incidents.IntegerEvaluator, Assembly-CSharp",
+            "propertyName": "Influence",
+            "Comparator": ">=",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "5",
+                  "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": true,
+                  "ExpressionType": 2,
+                  "constValue": 0,
+                  "chosenMethod": null,
+                  "chosenProperty": "ControlledTiles",
+                  "range": {
+                    "$id": "6",
+                    "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                    "randomRange": true,
+                    "min": 0,
+                    "max": 20,
+                    "constant": 0,
+                    "Value": 13,
+                    "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": "^",
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "7",
+                  "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": 2,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "8",
+                    "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                    "randomRange": true,
+                    "min": 0,
+                    "max": 20,
+                    "constant": 0,
+                    "Value": 6,
+                    "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        }
+      ]
+    }
+  },
+  "ActionContainer": {
+    "$id": "9",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "{0} expanded borders.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "10",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "11",
+            "$type": "Game.Incidents.ExpandBordersAction, Assembly-CSharp",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "Context": null
+          }
+        },
+        {
+          "$id": "12",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "13",
+            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+            "contextToModify": {
+              "$id": "14",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 1,
+              "NameID": "{1}:ModifyFactionAction:contextToModify",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "modifiers": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "15",
+                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                  "propertyName": "Influence",
+                  "calculator": {
+                    "$id": "16",
+                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                    "propertyName": "Influence",
+                    "Operation": "-",
+                    "expressions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "17",
+                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                          "hasNextOperator": true,
+                          "ExpressionType": 2,
+                          "constValue": 0,
+                          "chosenMethod": null,
+                          "chosenProperty": "ControlledTiles",
+                          "range": {
+                            "$id": "18",
+                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                            "randomRange": true,
+                            "min": 0,
+                            "max": 20,
+                            "constant": 0,
+                            "Value": 2,
+                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                          },
+                          "rangeWarning": "Range not implemented for non integers!",
+                          "nextOperator": "^",
+                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                        },
+                        {
+                          "$id": "19",
+                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                          "hasNextOperator": false,
+                          "ExpressionType": 0,
+                          "constValue": 2,
+                          "chosenMethod": null,
+                          "chosenProperty": null,
+                          "range": {
+                            "$id": "20",
+                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                            "randomRange": true,
+                            "min": 0,
+                            "max": 20,
+                            "constant": 0,
+                            "Value": 0,
+                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                          },
+                          "rangeWarning": "Range not implemented for non integers!",
+                          "nextOperator": null,
+                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                        }
+                      ]
+                    },
+                    "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "AllowMultipleExpressions": true
+                  },
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Faction Expand Territory Over Time.json.meta
+++ b/Assets/Resources/IncidentData/Faction Expand Territory Over Time.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 500536ee8b6e30c4ba38500f9db98c96
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Noble_Insulted.json
+++ b/Assets/Resources/IncidentData/Noble_Insulted.json
@@ -1,0 +1,417 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 2,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "ActionContainer": {
+    "$id": "3",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "{0} offered insult to {5}.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "4",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "5",
+            "$type": "Game.Incidents.GetOrCreatePersonAction, Assembly-CSharp",
+            "parent": {
+              "$id": "6",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 1,
+              "NameID": "{1}:GetOrCreatePersonAction:parent",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "race": {
+              "$id": "7",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Race, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 2,
+              "NameID": "{2}:GetOrCreatePersonAction:race",
+              "ActionFieldIDString": "{2}",
+              "ContextType": "Game.Incidents.Race, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "faction": {
+              "$id": "8",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 3,
+              "NameID": "{3}:GetOrCreatePersonAction:faction",
+              "ActionFieldIDString": "{3}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "gender": 0,
+            "age": {
+              "$id": "9",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 13,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "politicalPriority": {
+              "$id": "10",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 10,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "economicPriority": {
+              "$id": "11",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 2,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "religiousPriority": {
+              "$id": "12",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 10,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "militaryPriority": {
+              "$id": "13",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 0,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "14",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 5,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "15",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 3,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "strength": {
+              "$id": "16",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 16,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "dexterity": {
+              "$id": "17",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 10,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "constitution": {
+              "$id": "18",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 19,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "intelligence": {
+              "$id": "19",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 19,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wisdom": {
+              "$id": "20",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 4,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "charisma": {
+              "$id": "21",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 8,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": true,
+            "allowCreate": false,
+            "valueToFind": {
+              "$id": "22",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": [
+                  {
+                    "$id": "23",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "AffiliatedFaction",
+                    "evaluator": {
+                      "$id": "24",
+                      "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
+                      "Comparator": "!=",
+                      "toWho": "Mine",
+                      "Type": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  }
+                ]
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 4,
+              "NameID": "{4}:GetOrCreatePersonAction:valueToFind",
+              "ActionFieldIDString": "{4}",
+              "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "result": {
+              "$id": "25",
+              "$type": "Game.Incidents.ActionResultField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 2,
+              "ActionFieldID": 5,
+              "NameID": "{5}:GetOrCreatePersonAction:result",
+              "ActionFieldIDString": "{5}",
+              "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "26",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "27",
+            "$type": "Game.Incidents.GetPersonFactionAction, Assembly-CSharp",
+            "person": {
+              "$id": "28",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 6,
+              "NameID": "{6}:GetPersonFactionAction:person",
+              "ActionFieldIDString": "{6}",
+              "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "faction": {
+              "$id": "29",
+              "$type": "Game.Incidents.ActionResultField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 2,
+              "ActionFieldID": 7,
+              "NameID": "{7}:GetPersonFactionAction:faction",
+              "ActionFieldIDString": "{7}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "30",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "31",
+            "$type": "Game.Incidents.GetPersonFactionAction, Assembly-CSharp",
+            "person": {
+              "$id": "32",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{5}:GetOrCreatePersonAction:result",
+              "previousFieldID": 5,
+              "Method": 1,
+              "ActionFieldID": 8,
+              "NameID": "{8}:GetPersonFactionAction:person",
+              "ActionFieldIDString": "{8}",
+              "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "faction": {
+              "$id": "33",
+              "$type": "Game.Incidents.ActionResultField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 2,
+              "ActionFieldID": 9,
+              "NameID": "{9}:GetPersonFactionAction:faction",
+              "ActionFieldIDString": "{9}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "34",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "35",
+            "$type": "Game.Incidents.ChangeFactionRelationsAction, Assembly-CSharp",
+            "affectedFaction": {
+              "$id": "36",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{9}:GetPersonFactionAction:faction",
+              "previousFieldID": 9,
+              "Method": 1,
+              "ActionFieldID": 10,
+              "NameID": "{10}:ChangeFactionRelationsAction:affectedFaction",
+              "ActionFieldIDString": "{10}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "otherFaction": {
+              "$id": "37",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{7}:GetPersonFactionAction:faction",
+              "previousFieldID": 7,
+              "Method": 1,
+              "ActionFieldID": 11,
+              "NameID": "{11}:ChangeFactionRelationsAction:otherFaction",
+              "ActionFieldIDString": "{11}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "amount": {
+              "$id": "38",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": -10,
+              "max": -5,
+              "constant": 0,
+              "Value": -6,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Noble_Insulted.json
+++ b/Assets/Resources/IncidentData/Noble_Insulted.json
@@ -2,7 +2,7 @@
   "$id": "1",
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 2,
+  "Weight": 4,
   "Criteria": {
     "$id": "2",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
@@ -86,7 +86,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 13,
+              "Value": 10,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "politicalPriority": {
@@ -96,7 +96,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 10,
+              "Value": 0,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "economicPriority": {
@@ -106,7 +106,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 2,
+              "Value": 19,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "religiousPriority": {
@@ -116,7 +116,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 10,
+              "Value": 15,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "militaryPriority": {
@@ -126,7 +126,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 0,
+              "Value": 13,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "influence": {
@@ -136,7 +136,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 5,
+              "Value": 2,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "wealth": {
@@ -146,7 +146,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 3,
+              "Value": 9,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "strength": {
@@ -156,7 +156,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 16,
+              "Value": 18,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "dexterity": {
@@ -166,7 +166,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 10,
+              "Value": 5,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "constitution": {
@@ -176,7 +176,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 19,
+              "Value": 8,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "intelligence": {
@@ -186,7 +186,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 19,
+              "Value": 12,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "wisdom": {
@@ -196,7 +196,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 4,
+              "Value": 13,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "charisma": {
@@ -206,7 +206,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 8,
+              "Value": 13,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "findFirst": true,
@@ -227,9 +227,11 @@
                     "evaluator": {
                       "$id": "24",
                       "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
-                      "Comparator": "!=",
                       "toWho": "Mine",
-                      "Type": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                      "propertyName": null,
+                      "Comparator": "!=",
+                      "Type": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "ContextType": null
                     },
                     "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                     "PrimitiveType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
@@ -401,7 +403,7 @@
               "min": -10,
               "max": -5,
               "constant": 0,
-              "Value": -6,
+              "Value": -7,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             }
           }

--- a/Assets/Resources/IncidentData/Noble_Insulted.json.meta
+++ b/Assets/Resources/IncidentData/Noble_Insulted.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b138e92e81a335940a9bcb107adf4443
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_GoToWarWhenRelationsBelowThreshold.json
+++ b/Assets/Resources/IncidentData/Test_Faction_GoToWarWhenRelationsBelowThreshold.json
@@ -1,0 +1,344 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 13,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "3",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "FactionRelations",
+          "evaluator": {
+            "$id": "4",
+            "$type": "Game.Incidents.IntegerValueDictionaryEvaluator, Assembly-CSharp",
+            "propertyName": "FactionRelations",
+            "Comparator": "<=",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "5",
+                  "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": -100,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "6",
+                    "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                    "randomRange": true,
+                    "min": 0,
+                    "max": 20,
+                    "constant": 0,
+                    "Value": 0,
+                    "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Collections.Generic.Dictionary`2[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null],[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        },
+        {
+          "$id": "7",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "AtWar",
+          "evaluator": {
+            "$id": "8",
+            "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
+            "propertyName": "AtWar",
+            "Comparator": "==",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "9",
+                  "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": false,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "10",
+                    "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
+                    "Value": false,
+                    "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        }
+      ]
+    }
+  },
+  "ActionContainer": {
+    "$id": "11",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "Go to war when relations below threshold.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "12",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "13",
+            "$type": "Game.Incidents.GetOrCreateFactionAction, Assembly-CSharp",
+            "population": {
+              "$id": "14",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 5,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "15",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 9,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "16",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 1,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "politicalPriority": {
+              "$id": "17",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 12,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "economicPriority": {
+              "$id": "18",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 7,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "religiousPriority": {
+              "$id": "19",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 17,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "militaryPriority": {
+              "$id": "20",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 16,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": true,
+            "allowCreate": false,
+            "valueToFind": {
+              "$id": "21",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": [
+                  {
+                    "$id": "22",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "FactionRelations",
+                    "evaluator": {
+                      "$id": "23",
+                      "$type": "Game.Incidents.ActionFieldIntDictionaryEvaluator, Assembly-CSharp",
+                      "value": -100,
+                      "propertyName": "FactionRelations",
+                      "Comparator": "<=",
+                      "Type": "System.Collections.Generic.Dictionary`2[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null],[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                      "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "System.Collections.Generic.Dictionary`2[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null],[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  }
+                ]
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 1,
+              "NameID": "{1}:GetOrCreateFactionAction:valueToFind",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "result": {
+              "$id": "24",
+              "$type": "Game.Incidents.ActionResultField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 2,
+              "ActionFieldID": 2,
+              "NameID": "{2}:GetOrCreateFactionAction:result",
+              "ActionFieldIDString": "{2}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "25",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "26",
+            "$type": "Game.Incidents.ChangeWarStateAction, Assembly-CSharp",
+            "factionOne": {
+              "$id": "27",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 3,
+              "NameID": "{3}:ChangeWarStateAction:factionOne",
+              "ActionFieldIDString": "{3}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "factionTwo": {
+              "$id": "28",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{2}:GetOrCreateFactionAction:result",
+              "previousFieldID": 2,
+              "Method": 1,
+              "ActionFieldID": 4,
+              "NameID": "{4}:ChangeWarStateAction:factionTwo",
+              "ActionFieldIDString": "{4}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "atWar": true
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "29",
+          "$type": "Game.Incidents.ContextDeployer, Assembly-CSharp",
+          "delayTime": 0,
+          "deploymentCriteria": {
+            "$type": "System.Collections.Generic.List`1[[Game.Incidents.DeploymentCriterium, Assembly-CSharp]], mscorlib",
+            "$values": []
+          },
+          "incidentContext": {
+            "$id": "30",
+            "$type": "Game.Incidents.FactionBattleContext, Assembly-CSharp",
+            "attacker": {
+              "$id": "31",
+              "$type": "Game.Incidents.DeployedContextActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.ContextDeployer, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "ActionFieldIDString": "None",
+              "Method": 1,
+              "ActionFieldID": 0,
+              "NameID": null,
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "defender": {
+              "$id": "32",
+              "$type": "Game.Incidents.DeployedContextActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.ContextDeployer, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{2}:GetOrCreateFactionAction:result",
+              "previousFieldID": 2,
+              "ActionFieldIDString": "None",
+              "Method": 1,
+              "ActionFieldID": 0,
+              "NameID": null,
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "NumIncidents": 1,
+            "ID": 0,
+            "ParentID": 0
+          }
+        }
+      ]
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_GoToWarWhenRelationsBelowThreshold.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_GoToWarWhenRelationsBelowThreshold.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 21229f84e5c857e45aff0d33fc1097ef
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_LargeFactionRelationDegradation.json
+++ b/Assets/Resources/IncidentData/Test_Faction_LargeFactionRelationDegradation.json
@@ -1,0 +1,199 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 2,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "ActionContainer": {
+    "$id": "3",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "Randomly chosen large faction relation degradation.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "4",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "5",
+            "$type": "Game.Incidents.GetOrCreateFactionAction, Assembly-CSharp",
+            "population": {
+              "$id": "6",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 9,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "7",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 17,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "8",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 11,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "politicalPriority": {
+              "$id": "9",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 1,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "economicPriority": {
+              "$id": "10",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 5,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "religiousPriority": {
+              "$id": "11",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 11,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "militaryPriority": {
+              "$id": "12",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 16,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": true,
+            "allowCreate": false,
+            "valueToFind": {
+              "$id": "13",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 1,
+              "NameID": "{1}:GetOrCreateFactionAction:valueToFind",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "result": {
+              "$id": "14",
+              "$type": "Game.Incidents.ActionResultField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 2,
+              "ActionFieldID": 2,
+              "NameID": "{2}:GetOrCreateFactionAction:result",
+              "ActionFieldIDString": "{2}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "15",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "16",
+            "$type": "Game.Incidents.ChangeFactionRelationsAction, Assembly-CSharp",
+            "affectedFaction": {
+              "$id": "17",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 3,
+              "NameID": "{3}:ChangeFactionRelationsAction:affectedFaction",
+              "ActionFieldIDString": "{3}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "otherFaction": {
+              "$id": "18",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{2}:GetOrCreateFactionAction:result",
+              "previousFieldID": 2,
+              "Method": 1,
+              "ActionFieldID": 4,
+              "NameID": "{4}:ChangeFactionRelationsAction:otherFaction",
+              "ActionFieldIDString": "{4}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "amount": {
+              "$id": "19",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": -40,
+              "max": -25,
+              "constant": 0,
+              "Value": -32,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_LargeFactionRelationDegradation.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_LargeFactionRelationDegradation.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 255eb4c4e36a85a42baab3e6f0323e53
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_MakePeace.json
+++ b/Assets/Resources/IncidentData/Test_Faction_MakePeace.json
@@ -1,0 +1,301 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 1,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "3",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "AtWar",
+          "evaluator": {
+            "$id": "4",
+            "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
+            "propertyName": "AtWar",
+            "Comparator": "==",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "5",
+                  "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": true,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "6",
+                    "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
+                    "Value": false,
+                    "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        },
+        {
+          "$id": "7",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "CouldMakePeace",
+          "evaluator": {
+            "$id": "8",
+            "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
+            "propertyName": "CouldMakePeace",
+            "Comparator": "==",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "9",
+                  "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": true,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "10",
+                    "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
+                    "Value": false,
+                    "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        }
+      ]
+    }
+  },
+  "ActionContainer": {
+    "$id": "11",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "Improved relations lead to peace between {0} and {2}.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "12",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "13",
+            "$type": "Game.Incidents.GetOrCreateFactionAction, Assembly-CSharp",
+            "population": {
+              "$id": "14",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 1,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "15",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 10,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "16",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 14,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "politicalPriority": {
+              "$id": "17",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 2,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "economicPriority": {
+              "$id": "18",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 6,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "religiousPriority": {
+              "$id": "19",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 1,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "militaryPriority": {
+              "$id": "20",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 7,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": true,
+            "allowCreate": false,
+            "valueToFind": {
+              "$id": "21",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": [
+                  {
+                    "$id": "22",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "FactionsAtWarWith",
+                    "evaluator": {
+                      "$id": "23",
+                      "$type": "Game.Incidents.ActionFieldListContainsEvaluator, Assembly-CSharp",
+                      "propertyName": "FactionsAtWarWith",
+                      "Comparator": "==",
+                      "Type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                      "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  {
+                    "$id": "24",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "FactionRelations",
+                    "evaluator": {
+                      "$id": "25",
+                      "$type": "Game.Incidents.ActionFieldIntDictionaryEvaluator, Assembly-CSharp",
+                      "value": 0,
+                      "propertyName": "FactionRelations",
+                      "Comparator": ">=",
+                      "Type": "System.Collections.Generic.Dictionary`2[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null],[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                      "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "System.Collections.Generic.Dictionary`2[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null],[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  }
+                ]
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 1,
+              "NameID": "{1}:GetOrCreateFactionAction:valueToFind",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "result": {
+              "$id": "26",
+              "$type": "Game.Incidents.ActionResultField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 2,
+              "ActionFieldID": 2,
+              "NameID": "{2}:GetOrCreateFactionAction:result",
+              "ActionFieldIDString": "{2}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "27",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "28",
+            "$type": "Game.Incidents.ChangeWarStateAction, Assembly-CSharp",
+            "factionOne": {
+              "$id": "29",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 3,
+              "NameID": "{3}:ChangeWarStateAction:factionOne",
+              "ActionFieldIDString": "{3}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "factionTwo": {
+              "$id": "30",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{2}:GetOrCreateFactionAction:result",
+              "previousFieldID": 2,
+              "Method": 1,
+              "ActionFieldID": 4,
+              "NameID": "{4}:ChangeWarStateAction:factionTwo",
+              "ActionFieldIDString": "{4}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "atWar": false
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_MakePeace.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_MakePeace.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 28e89cfa6db5b7e448cef694ead57b3c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_MediumFactionRelationDegradation.json
+++ b/Assets/Resources/IncidentData/Test_Faction_MediumFactionRelationDegradation.json
@@ -1,0 +1,199 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 3,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "ActionContainer": {
+    "$id": "3",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "Randomly chosen medium faction relation degradation.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "4",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "5",
+            "$type": "Game.Incidents.GetOrCreateFactionAction, Assembly-CSharp",
+            "population": {
+              "$id": "6",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 0,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "7",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 14,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "8",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 14,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "politicalPriority": {
+              "$id": "9",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 15,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "economicPriority": {
+              "$id": "10",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 3,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "religiousPriority": {
+              "$id": "11",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 8,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "militaryPriority": {
+              "$id": "12",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 3,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": true,
+            "allowCreate": false,
+            "valueToFind": {
+              "$id": "13",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 1,
+              "NameID": "{1}:GetOrCreateFactionAction:valueToFind",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "result": {
+              "$id": "14",
+              "$type": "Game.Incidents.ActionResultField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 2,
+              "ActionFieldID": 2,
+              "NameID": "{2}:GetOrCreateFactionAction:result",
+              "ActionFieldIDString": "{2}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "15",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "16",
+            "$type": "Game.Incidents.ChangeFactionRelationsAction, Assembly-CSharp",
+            "affectedFaction": {
+              "$id": "17",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 3,
+              "NameID": "{3}:ChangeFactionRelationsAction:affectedFaction",
+              "ActionFieldIDString": "{3}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "otherFaction": {
+              "$id": "18",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{2}:GetOrCreateFactionAction:result",
+              "previousFieldID": 2,
+              "Method": 1,
+              "ActionFieldID": 4,
+              "NameID": "{4}:ChangeFactionRelationsAction:otherFaction",
+              "ActionFieldIDString": "{4}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "amount": {
+              "$id": "19",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": -25,
+              "max": -15,
+              "constant": 0,
+              "Value": -24,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_MediumFactionRelationDegradation.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_MediumFactionRelationDegradation.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3c61efa8193a9a44291d411ff240c61f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_MiraculousPeaceTreaty.json
+++ b/Assets/Resources/IncidentData/Test_Faction_MiraculousPeaceTreaty.json
@@ -1,0 +1,341 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 1,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "3",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "AtWar",
+          "evaluator": {
+            "$id": "4",
+            "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
+            "propertyName": "AtWar",
+            "Comparator": "==",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "5",
+                  "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": true,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "6",
+                    "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
+                    "Value": false,
+                    "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        },
+        {
+          "$id": "7",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "CouldMakePeace",
+          "evaluator": {
+            "$id": "8",
+            "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
+            "propertyName": "CouldMakePeace",
+            "Comparator": "==",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "9",
+                  "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": true,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "10",
+                    "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
+                    "Value": false,
+                    "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        }
+      ]
+    }
+  },
+  "ActionContainer": {
+    "$id": "11",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "Miraculous peace treaty between {0} and {2}.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "12",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "13",
+            "$type": "Game.Incidents.GetOrCreateFactionAction, Assembly-CSharp",
+            "population": {
+              "$id": "14",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 5,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "15",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 2,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "16",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 17,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "politicalPriority": {
+              "$id": "17",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 15,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "economicPriority": {
+              "$id": "18",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 10,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "religiousPriority": {
+              "$id": "19",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 0,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "militaryPriority": {
+              "$id": "20",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 19,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": true,
+            "allowCreate": false,
+            "valueToFind": {
+              "$id": "21",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": [
+                  {
+                    "$id": "22",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "FactionsAtWarWith",
+                    "evaluator": {
+                      "$id": "23",
+                      "$type": "Game.Incidents.ActionFieldListContainsEvaluator, Assembly-CSharp",
+                      "propertyName": "FactionsAtWarWith",
+                      "Comparator": "==",
+                      "Type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                      "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  }
+                ]
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 1,
+              "NameID": "{1}:GetOrCreateFactionAction:valueToFind",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "result": {
+              "$id": "24",
+              "$type": "Game.Incidents.ActionResultField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 2,
+              "ActionFieldID": 2,
+              "NameID": "{2}:GetOrCreateFactionAction:result",
+              "ActionFieldIDString": "{2}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "25",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "26",
+            "$type": "Game.Incidents.ChangeWarStateAction, Assembly-CSharp",
+            "factionOne": {
+              "$id": "27",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 3,
+              "NameID": "{3}:ChangeWarStateAction:factionOne",
+              "ActionFieldIDString": "{3}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "factionTwo": {
+              "$id": "28",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{2}:GetOrCreateFactionAction:result",
+              "previousFieldID": 2,
+              "Method": 1,
+              "ActionFieldID": 4,
+              "NameID": "{4}:ChangeWarStateAction:factionTwo",
+              "ActionFieldIDString": "{4}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "atWar": false
+          }
+        },
+        {
+          "$id": "29",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "30",
+            "$type": "Game.Incidents.ChangeFactionRelationsAction, Assembly-CSharp",
+            "affectedFaction": {
+              "$id": "31",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 5,
+              "NameID": "{5}:ChangeFactionRelationsAction:affectedFaction",
+              "ActionFieldIDString": "{5}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "otherFaction": {
+              "$id": "32",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{2}:GetOrCreateFactionAction:result",
+              "previousFieldID": 2,
+              "Method": 1,
+              "ActionFieldID": 6,
+              "NameID": "{6}:ChangeFactionRelationsAction:otherFaction",
+              "ActionFieldIDString": "{6}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "amount": {
+              "$id": "33",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": false,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 0,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "set": true,
+            "mirrored": true
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_MiraculousPeaceTreaty.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_MiraculousPeaceTreaty.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c7dca52aa41057f4b840fd07a2ff1a21
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_RandomFactionInfluenceChange.json
+++ b/Assets/Resources/IncidentData/Test_Faction_RandomFactionInfluenceChange.json
@@ -1,0 +1,103 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 5,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "ActionContainer": {
+    "$id": "3",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": null,
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "4",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "5",
+            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+            "contextToModify": {
+              "$id": "6",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 1,
+              "NameID": "{1}:ModifyFactionAction:contextToModify",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "modifiers": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "7",
+                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                  "propertyName": "Influence",
+                  "calculator": {
+                    "$id": "8",
+                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                    "propertyName": "Influence",
+                    "Operation": "+",
+                    "expressions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "9",
+                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                          "hasNextOperator": false,
+                          "ExpressionType": 3,
+                          "constValue": 0,
+                          "chosenMethod": null,
+                          "chosenProperty": null,
+                          "range": {
+                            "$id": "10",
+                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                            "randomRange": true,
+                            "min": -10,
+                            "max": 10,
+                            "constant": 0,
+                            "Value": 5,
+                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                          },
+                          "rangeWarning": "Range not implemented for non integers!",
+                          "nextOperator": null,
+                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                        }
+                      ]
+                    },
+                    "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "AllowMultipleExpressions": true
+                  },
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_RandomFactionInfluenceChange.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_RandomFactionInfluenceChange.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 23f6a3094bc94d44db77d4453deefc17
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_RandomFactionWealthChange.json
+++ b/Assets/Resources/IncidentData/Test_Faction_RandomFactionWealthChange.json
@@ -1,0 +1,103 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 5,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "ActionContainer": {
+    "$id": "3",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": null,
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "4",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "5",
+            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+            "contextToModify": {
+              "$id": "6",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 1,
+              "NameID": "{1}:ModifyFactionAction:contextToModify",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "modifiers": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "7",
+                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                  "propertyName": "Wealth",
+                  "calculator": {
+                    "$id": "8",
+                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                    "propertyName": "Wealth",
+                    "Operation": "+",
+                    "expressions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "9",
+                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                          "hasNextOperator": false,
+                          "ExpressionType": 3,
+                          "constValue": 0,
+                          "chosenMethod": null,
+                          "chosenProperty": null,
+                          "range": {
+                            "$id": "10",
+                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                            "randomRange": true,
+                            "min": -20,
+                            "max": 20,
+                            "constant": 0,
+                            "Value": 7,
+                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                          },
+                          "rangeWarning": "Range not implemented for non integers!",
+                          "nextOperator": null,
+                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                        }
+                      ]
+                    },
+                    "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "AllowMultipleExpressions": true
+                  },
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_RandomFactionWealthChange.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_RandomFactionWealthChange.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9f730f68a8ef0434b8b98b760f334e44
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_RelationsImproveWhileAtWar.json
+++ b/Assets/Resources/IncidentData/Test_Faction_RelationsImproveWhileAtWar.json
@@ -1,0 +1,256 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 3,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "3",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "AtWar",
+          "evaluator": {
+            "$id": "4",
+            "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
+            "propertyName": "AtWar",
+            "Comparator": "==",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "5",
+                  "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": true,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "6",
+                    "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
+                    "Value": false,
+                    "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        }
+      ]
+    }
+  },
+  "ActionContainer": {
+    "$id": "7",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "Relations imrpove between {0} and {2}.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "8",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "9",
+            "$type": "Game.Incidents.GetOrCreateFactionAction, Assembly-CSharp",
+            "population": {
+              "$id": "10",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 1,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "11",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 10,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "12",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 14,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "politicalPriority": {
+              "$id": "13",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 2,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "economicPriority": {
+              "$id": "14",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 6,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "religiousPriority": {
+              "$id": "15",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 1,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "militaryPriority": {
+              "$id": "16",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 7,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": true,
+            "allowCreate": false,
+            "valueToFind": {
+              "$id": "17",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": [
+                  {
+                    "$id": "18",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "FactionsAtWarWith",
+                    "evaluator": {
+                      "$id": "19",
+                      "$type": "Game.Incidents.ActionFieldListContainsEvaluator, Assembly-CSharp",
+                      "propertyName": "FactionsAtWarWith",
+                      "Comparator": "==",
+                      "Type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                      "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  }
+                ]
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 1,
+              "NameID": "{1}:GetOrCreateFactionAction:valueToFind",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "result": {
+              "$id": "20",
+              "$type": "Game.Incidents.ActionResultField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 2,
+              "ActionFieldID": 2,
+              "NameID": "{2}:GetOrCreateFactionAction:result",
+              "ActionFieldIDString": "{2}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "21",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "22",
+            "$type": "Game.Incidents.ChangeFactionRelationsAction, Assembly-CSharp",
+            "affectedFaction": {
+              "$id": "23",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 5,
+              "NameID": "{5}:ChangeFactionRelationsAction:affectedFaction",
+              "ActionFieldIDString": "{5}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "otherFaction": {
+              "$id": "24",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{2}:GetOrCreateFactionAction:result",
+              "previousFieldID": 2,
+              "Method": 1,
+              "ActionFieldID": 6,
+              "NameID": "{6}:ChangeFactionRelationsAction:otherFaction",
+              "ActionFieldIDString": "{6}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "amount": {
+              "$id": "25",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 20,
+              "max": 40,
+              "constant": 120,
+              "Value": 25,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "mirrored": true
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_RelationsImproveWhileAtWar.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_RelationsImproveWhileAtWar.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5f096477040e5f04a96fc190bafffc14
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_SendBattleContextIfAtWar.json
+++ b/Assets/Resources/IncidentData/Test_Faction_SendBattleContextIfAtWar.json
@@ -1,0 +1,255 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 7,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "3",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "AtWar",
+          "evaluator": {
+            "$id": "4",
+            "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
+            "propertyName": "AtWar",
+            "Comparator": "==",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "5",
+                  "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": true,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "6",
+                    "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
+                    "Value": false,
+                    "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        }
+      ]
+    }
+  },
+  "ActionContainer": {
+    "$id": "7",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "Sent battle context because at war.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "8",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "9",
+            "$type": "Game.Incidents.GetOrCreateFactionAction, Assembly-CSharp",
+            "population": {
+              "$id": "10",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 15,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "11",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 1,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "12",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 19,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "politicalPriority": {
+              "$id": "13",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 5,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "economicPriority": {
+              "$id": "14",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 7,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "religiousPriority": {
+              "$id": "15",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 17,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "militaryPriority": {
+              "$id": "16",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 16,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": true,
+            "allowCreate": false,
+            "valueToFind": {
+              "$id": "17",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": [
+                  {
+                    "$id": "18",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "FactionsAtWarWith",
+                    "evaluator": {
+                      "$id": "19",
+                      "$type": "Game.Incidents.ActionFieldListContainsEvaluator, Assembly-CSharp",
+                      "propertyName": "FactionsAtWarWith",
+                      "Comparator": "==",
+                      "Type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                      "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  }
+                ]
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 0,
+              "ActionFieldID": 1,
+              "NameID": "{1}:GetOrCreateFactionAction:valueToFind",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "result": {
+              "$id": "20",
+              "$type": "Game.Incidents.ActionResultField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "Method": 2,
+              "ActionFieldID": 2,
+              "NameID": "{2}:GetOrCreateFactionAction:result",
+              "ActionFieldIDString": "{2}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "21",
+          "$type": "Game.Incidents.ContextDeployer, Assembly-CSharp",
+          "delayTime": 0,
+          "deploymentCriteria": {
+            "$type": "System.Collections.Generic.List`1[[Game.Incidents.DeploymentCriterium, Assembly-CSharp]], mscorlib",
+            "$values": []
+          },
+          "incidentContext": {
+            "$id": "22",
+            "$type": "Game.Incidents.FactionBattleContext, Assembly-CSharp",
+            "attacker": {
+              "$id": "23",
+              "$type": "Game.Incidents.DeployedContextActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.ContextDeployer, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "ActionFieldIDString": "None",
+              "Method": 1,
+              "ActionFieldID": 0,
+              "NameID": null,
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "defender": {
+              "$id": "24",
+              "$type": "Game.Incidents.DeployedContextActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.ContextDeployer, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{2}:GetOrCreateFactionAction:result",
+              "previousFieldID": 2,
+              "ActionFieldIDString": "None",
+              "Method": 1,
+              "ActionFieldID": 0,
+              "NameID": null,
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "NumIncidents": 1,
+            "ID": 0,
+            "ParentID": 0
+          }
+        }
+      ]
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_SendBattleContextIfAtWar.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_SendBattleContextIfAtWar.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c78dd1e5bae5c34891998f93b7c2c84
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Person_RandomModifyPersonInfluence.json
+++ b/Assets/Resources/IncidentData/Test_Person_RandomModifyPersonInfluence.json
@@ -1,0 +1,103 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weight": 5,
+  "Criteria": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "ActionContainer": {
+    "$id": "3",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": null,
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "4",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "5",
+            "$type": "Game.Incidents.ModifyPersonAction, Assembly-CSharp",
+            "contextToModify": {
+              "$id": "6",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "Method": 1,
+              "ActionFieldID": 1,
+              "NameID": "{1}:ModifyPersonAction:contextToModify",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "modifiers": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "7",
+                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+                  "propertyName": "Influence",
+                  "calculator": {
+                    "$id": "8",
+                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                    "propertyName": "Influence",
+                    "Operation": "+",
+                    "expressions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "9",
+                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                          "hasNextOperator": false,
+                          "ExpressionType": 3,
+                          "constValue": 0,
+                          "chosenMethod": null,
+                          "chosenProperty": null,
+                          "range": {
+                            "$id": "10",
+                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                            "randomRange": true,
+                            "min": -5,
+                            "max": 5,
+                            "constant": 0,
+                            "Value": -1,
+                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                          },
+                          "rangeWarning": "Range not implemented for non integers!",
+                          "nextOperator": null,
+                          "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                        }
+                      ]
+                    },
+                    "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "AllowMultipleExpressions": true
+                  },
+                  "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Person_RandomModifyPersonInfluence.json.meta
+++ b/Assets/Resources/IncidentData/Test_Person_RandomModifyPersonInfluence.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6ce657f71aa3ff546bba5fb6300fb365
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/ContextDeployer.cs
+++ b/Assets/Scripts/Incidents/ContextDeployer.cs
@@ -166,12 +166,4 @@ namespace Game.Incidents
 		{
 		}
 	}
-
-	public class WarDeclaredContext : DeployableContext
-	{
-		[HideReferenceObjectPicker]
-		public DeployedContextActionField<Faction> faction1;
-		[HideReferenceObjectPicker]
-		public DeployedContextActionField<Faction> faction2;
-	}
 }

--- a/Assets/Scripts/Incidents/Contexts/DeployedContexts.meta
+++ b/Assets/Scripts/Incidents/Contexts/DeployedContexts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b37d0429cc13714193762b92ff58fbc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Contexts/DeployedContexts/FactionBattleContext.cs
+++ b/Assets/Scripts/Incidents/Contexts/DeployedContexts/FactionBattleContext.cs
@@ -1,0 +1,12 @@
+﻿using Sirenix.OdinInspector;
+
+namespace Game.Incidents
+{
+	public class FactionBattleContext : DeployableContext
+	{
+		[HideReferenceObjectPicker]
+		public DeployedContextActionField<Faction> attacker;
+		[HideReferenceObjectPicker]
+		public DeployedContextActionField<Faction> defender;
+	}
+}

--- a/Assets/Scripts/Incidents/Contexts/DeployedContexts/FactionBattleContext.cs.meta
+++ b/Assets/Scripts/Incidents/Contexts/DeployedContexts/FactionBattleContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa2fb43075e1cab4a84523055269d134
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Contexts/Faction.cs
+++ b/Assets/Scripts/Incidents/Contexts/Faction.cs
@@ -24,7 +24,7 @@ namespace Game.Incidents
 		public int EconomicPriority { get; set; }
 		public int ReligiousPriority { get; set; }
 		public int MilitaryPriority { get; set; }
-		public List<Faction> FactionsAtWarWith { get; set; }
+		public List<IIncidentContext> FactionsAtWarWith { get; set; }
 
 		public bool AtWar => FactionsAtWarWith.Count > 0;
 		virtual public bool CanExpandTerritory => true;
@@ -43,7 +43,7 @@ namespace Game.Incidents
 			AttemptExpandBorder(startingTiles);
 			FactionRelations = new Dictionary<IIncidentContext, int>();
 			Cities = new List<City>();
-			FactionsAtWarWith = new List<Faction>();
+			FactionsAtWarWith = new List<IIncidentContext>();
 			CreateStartingCity();
 			CreateStartingGovernment();
 		}

--- a/Assets/Scripts/Incidents/Contexts/Faction.cs
+++ b/Assets/Scripts/Incidents/Contexts/Faction.cs
@@ -27,6 +27,7 @@ namespace Game.Incidents
 		public List<IIncidentContext> FactionsAtWarWith { get; set; }
 
 		public bool AtWar => FactionsAtWarWith.Count > 0;
+		public bool CouldMakePeace => FactionsAtWarWith.Where(x => FactionRelations[x] >= 0).ToList().Count >= 1;
 		virtual public bool CanExpandTerritory => true;
 		virtual public bool CanTakeMilitaryAction => true;
 		public Government Government { get; set; }

--- a/Assets/Scripts/Incidents/Contexts/Faction.cs
+++ b/Assets/Scripts/Incidents/Contexts/Faction.cs
@@ -17,6 +17,7 @@ namespace Game.Incidents
 		public int Population { get; set; }
 		public int Influence { get; set; }
 		public int Wealth { get; set; }
+		public int MilitaryPower { get; set; }
 		public Dictionary<IIncidentContext, int> FactionRelations { get; set; }
 		public int ControlledTiles => ControlledTileIndices.Count;
 		public List<City> Cities { get; set; }

--- a/Assets/Scripts/Incidents/Contexts/Faction.cs
+++ b/Assets/Scripts/Incidents/Contexts/Faction.cs
@@ -13,6 +13,7 @@ namespace Game.Incidents
 	public class Faction : IncidentContext, IFactionAffiliated
 	{
 		public Faction AffiliatedFaction => this;
+		public Type FactionType => ContextType;
 		public int Population { get; set; }
 		public int Influence { get; set; }
 		public int Wealth { get; set; }

--- a/Assets/Scripts/Incidents/Contexts/Government.cs
+++ b/Assets/Scripts/Incidents/Contexts/Government.cs
@@ -15,7 +15,12 @@ namespace Game.Incidents
 
 		public void SelectNewLeader()
 		{
-			Leader = new Person(35, Enums.Gender.ANY, null, AffiliatedFaction, 5, 5, 5, 5, 0, 0, 10, 10, 10, 10, 10, 10);
+			var leaderRace = Leader == null ? new Race() : Leader.Race;
+			if(Leader == null)
+			{
+				SimulationManager.Instance.world.AddContext(leaderRace);
+			}
+			Leader = new Person(35, Enums.Gender.ANY, leaderRace, AffiliatedFaction, 5, 5, 5, 5, 0, 0, 10, 10, 10, 10, 10, 10);
 			Leader.SetOnDeathAction(SelectNewLeader);
 			SimulationManager.Instance.world.AddContext(Leader);
 		}

--- a/Assets/Scripts/Incidents/Contexts/Special Factions/BandOfThieves.cs
+++ b/Assets/Scripts/Incidents/Contexts/Special Factions/BandOfThieves.cs
@@ -1,0 +1,7 @@
+﻿namespace Game.Incidents
+{
+	public class BandOfThieves : SpecialFaction
+	{
+		public override bool CanExpandTerritory => false;
+	}
+}

--- a/Assets/Scripts/Incidents/Contexts/Special Factions/BandOfThieves.cs.meta
+++ b/Assets/Scripts/Incidents/Contexts/Special Factions/BandOfThieves.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69197c71218aeb94698e0436373cf253
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldCriteriaEvaluator.cs
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldCriteriaEvaluator.cs
@@ -1,0 +1,42 @@
+﻿using Sirenix.OdinInspector;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Incidents
+{
+	abstract public class ActionFieldCriteriaEvaluator<T, V> : ICriteriaEvaluator
+	{
+		//Next step would be to make this inherit from CriteriaEvaluator not just the interface
+		protected Dictionary<string, Func<V, V,bool>> Comparators { get; set; }
+
+		public Type Type => typeof(T);
+		public Type ContextType { get; set; }
+
+		[HorizontalGroup("Group 1", 150), HideLabel, ReadOnly]
+		public string propertyName;
+
+		[ValueDropdown("GetComparatorNames"), HorizontalGroup("Group 1", 50), HideLabel]
+		public string Comparator;
+
+		public ActionFieldCriteriaEvaluator()
+		{
+			Setup();
+		}
+
+		public ActionFieldCriteriaEvaluator(string propertyName, Type contextType) : this()
+		{
+			this.propertyName = propertyName;
+			ContextType = contextType;
+		}
+
+		abstract public bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext = null);
+
+		abstract public void Setup();
+
+		private List<string> GetComparatorNames()
+		{
+			return Comparators.Keys.ToList();
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldCriteriaEvaluator.cs.meta
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldCriteriaEvaluator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45d6c56e864389042b6b925ee3e7a8ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldIntDictionaryEvaluator.cs
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldIntDictionaryEvaluator.cs
@@ -1,0 +1,28 @@
+﻿using Sirenix.OdinInspector;
+using System;
+using System.Collections.Generic;
+
+namespace Game.Incidents
+{
+	public class ActionFieldIntDictionaryEvaluator : ActionFieldCriteriaEvaluator<Dictionary<IIncidentContext, int>, int>
+	{
+		[HorizontalGroup("Group 1")]
+		public int value;
+		public ActionFieldIntDictionaryEvaluator() { }
+		public ActionFieldIntDictionaryEvaluator(string propertyName, Type contextType) : base(propertyName, contextType) { }
+		public override bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext = null)
+		{
+			var propertyValue = (Dictionary<IIncidentContext, int>)parentContext.GetType().GetProperty(propertyName).GetValue(parentContext);
+			if(propertyValue.ContainsKey(context))
+			{
+				return Comparators[Comparator].Invoke(propertyValue[context], value);
+			}
+			return false;
+		}
+
+		public override void Setup()
+		{
+			Comparators = ExpressionHelpers.IntegerComparators;
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldIntDictionaryEvaluator.cs.meta
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldIntDictionaryEvaluator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa2b480b83d079f48a241185c901d578
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldListContainsEvaluator.cs
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldListContainsEvaluator.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Game.Incidents
+{
+	public class ActionFieldListContainsEvaluator : ActionFieldCriteriaEvaluator<List<IIncidentContext>, bool>
+	{
+		public ActionFieldListContainsEvaluator() { }
+		public ActionFieldListContainsEvaluator(string propertyName, Type contextType) : base(propertyName, contextType) { }
+		public override bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext = null)
+		{
+			var propertyValue = (List<IIncidentContext>)parentContext.GetType().GetProperty(propertyName).GetValue(parentContext);
+			return Comparators[Comparator].Invoke(propertyValue.Contains(context), true);
+		}
+
+		public override void Setup()
+		{
+			Comparators = ExpressionHelpers.BoolComparators;
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldListContainsEvaluator.cs.meta
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/ActionFieldListContainsEvaluator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2fdef68f2e9db44385afa3de3f633dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/ContextEvaluator.cs
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/ContextEvaluator.cs
@@ -1,7 +1,4 @@
 ﻿using Sirenix.OdinInspector;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Game.Incidents
 {
@@ -25,63 +22,6 @@ namespace Game.Incidents
 		override public void Setup()
 		{
 			Comparators = ExpressionHelpers.ContextComparators;
-		}
-	}
-
-	abstract public class ActionFieldCriteriaEvaluator<T, V> : ICriteriaEvaluator
-	{
-		//Next step would be to make this inherit from CriteriaEvaluator not just the interface
-		protected Dictionary<string, Func<V, V,bool>> Comparators { get; set; }
-
-		public Type Type => typeof(T);
-		public Type ContextType { get; set; }
-
-		[HorizontalGroup("Group 1", 150), HideLabel, ReadOnly]
-		public string propertyName;
-
-		[ValueDropdown("GetComparatorNames"), HorizontalGroup("Group 1", 50), HideLabel]
-		public string Comparator;
-
-		public ActionFieldCriteriaEvaluator()
-		{
-			Setup();
-		}
-
-		public ActionFieldCriteriaEvaluator(string propertyName, Type contextType) : this()
-		{
-			this.propertyName = propertyName;
-			ContextType = contextType;
-		}
-
-		abstract public bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext = null);
-
-		abstract public void Setup();
-
-		private List<string> GetComparatorNames()
-		{
-			return Comparators.Keys.ToList();
-		}
-	}
-
-	public class ActionFieldIntDictionaryEvaluator : ActionFieldCriteriaEvaluator<Dictionary<IIncidentContext, int>, int>
-	{
-		[HorizontalGroup("Group 1")]
-		public int value;
-		public ActionFieldIntDictionaryEvaluator() { }
-		public ActionFieldIntDictionaryEvaluator(string propertyName, Type contextType) : base(propertyName, contextType) { }
-		public override bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext = null)
-		{
-			var propertyValue = (Dictionary<IIncidentContext, int>)context.GetType().GetProperty(propertyName).GetValue(context);
-			if(propertyValue.ContainsKey(context))
-			{
-				return Comparators[Comparator].Invoke(propertyValue[context], value);
-			}
-			return false;
-		}
-
-		public override void Setup()
-		{
-			Comparators = ExpressionHelpers.IntegerComparators;
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/ContextEvaluator.cs
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/ContextEvaluator.cs
@@ -5,24 +5,14 @@ using System.Linq;
 
 namespace Game.Incidents
 {
-	abstract public class ContextEvaluator<T> : ICriteriaEvaluator where T : IIncidentContext
+	abstract public class ContextEvaluator<T> : ActionFieldCriteriaEvaluator<T, IIncidentContext> where T: IIncidentContext
 	{
-		protected Dictionary<string, Func<IIncidentContext, IIncidentContext, bool>> Comparators { get; set; }
-
-		[ValueDropdown("GetComparatorNames"), HorizontalGroup("Group 1", 50), HideLabel]
-		public string Comparator;
-
 		[HorizontalGroup("Group 1", 100), ReadOnly, HideLabel]
 		public string toWho = "Mine";
 
-		public Type Type => typeof(T);
+		public ContextEvaluator() : base() { }
 
-		public ContextEvaluator()
-		{
-			Setup();
-		}
-
-		public bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext)
+		override public bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext)
 		{
 			var parentValue = GetContext(parentContext);
 			var contextValue = GetContext(context);
@@ -32,14 +22,66 @@ namespace Game.Incidents
 
 		abstract protected T GetContext(IIncidentContext context);
 
-		virtual public void Setup()
+		override public void Setup()
 		{
 			Comparators = ExpressionHelpers.ContextComparators;
 		}
+	}
+
+	abstract public class ActionFieldCriteriaEvaluator<T, V> : ICriteriaEvaluator
+	{
+		//Next step would be to make this inherit from CriteriaEvaluator not just the interface
+		protected Dictionary<string, Func<V, V,bool>> Comparators { get; set; }
+
+		public Type Type => typeof(T);
+		public Type ContextType { get; set; }
+
+		[HorizontalGroup("Group 1", 150), HideLabel, ReadOnly]
+		public string propertyName;
+
+		[ValueDropdown("GetComparatorNames"), HorizontalGroup("Group 1", 50), HideLabel]
+		public string Comparator;
+
+		public ActionFieldCriteriaEvaluator()
+		{
+			Setup();
+		}
+
+		public ActionFieldCriteriaEvaluator(string propertyName, Type contextType) : this()
+		{
+			this.propertyName = propertyName;
+			ContextType = contextType;
+		}
+
+		abstract public bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext = null);
+
+		abstract public void Setup();
 
 		private List<string> GetComparatorNames()
 		{
 			return Comparators.Keys.ToList();
+		}
+	}
+
+	public class ActionFieldIntDictionaryEvaluator : ActionFieldCriteriaEvaluator<Dictionary<IIncidentContext, int>, int>
+	{
+		[HorizontalGroup("Group 1")]
+		public int value;
+		public ActionFieldIntDictionaryEvaluator() { }
+		public ActionFieldIntDictionaryEvaluator(string propertyName, Type contextType) : base(propertyName, contextType) { }
+		public override bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext = null)
+		{
+			var propertyValue = (Dictionary<IIncidentContext, int>)context.GetType().GetProperty(propertyName).GetValue(context);
+			if(propertyValue.ContainsKey(context))
+			{
+				return Comparators[Comparator].Invoke(propertyValue[context], value);
+			}
+			return false;
+		}
+
+		public override void Setup()
+		{
+			Comparators = ExpressionHelpers.IntegerComparators;
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/CriteriaEvaluator.cs
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/CriteriaEvaluator.cs
@@ -23,9 +23,10 @@ namespace Game.Incidents
         [ValueDropdown("GetComparatorNames"), OnValueChanged("SetComparatorType"), HorizontalGroup("Group 1", 50), HideLabel]
         public string Comparator;
 
-        [ListDrawerSettings(CustomAddFunction = "AddNewExpression"), HorizontalGroup("Group 1"), HideReferenceObjectPicker]
+        [ShowIf("UseExpressions"), ListDrawerSettings(CustomAddFunction = "AddNewExpression"), HorizontalGroup("Group 1"), HideReferenceObjectPicker]
         public List<Expression<T>> expressions;
         virtual public bool AllowMultipleExpressions => true;
+        virtual protected bool UseExpressions => true;
 
         public bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext = null)
         {

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/TypeEvaluator.cs
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/TypeEvaluator.cs
@@ -1,0 +1,36 @@
+﻿using Sirenix.OdinInspector;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Game.Incidents
+{
+	public class TypeEvaluator : CriteriaEvaluator<Type>
+	{
+		protected override bool UseExpressions => false;
+
+		[ValueDropdown("GetFilteredTypeList"), LabelText("Compare To Type")]
+		public Type comparedType;
+		public TypeEvaluator(string propertyName, Type contextType) : base(propertyName, contextType) { }
+		public override void Setup()
+		{
+			Comparators = ExpressionHelpers.TypeComparators;
+		}
+
+		protected override bool Evaluate(IIncidentContext context, string propertyName)
+		{
+			var propertyValue = (Type)context.GetType().GetProperty(propertyName).GetValue(context);
+			return Comparators[Comparator].Invoke(propertyValue, comparedType);
+		}
+
+		private IEnumerable<Type> GetFilteredTypeList()
+		{
+			var q = ContextType.Assembly.GetTypes()
+				.Where(x => !x.IsAbstract)                                          // Excludes BaseClass
+				.Where(x => !x.IsGenericTypeDefinition)                             // Excludes Generics
+				.Where(x => ContextType.IsAssignableFrom(x));           // Excludes classes not inheriting from IIncidentContext
+
+			return q;
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/TypeEvaluator.cs.meta
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/TypeEvaluator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d04254eb79e772d40b2a51959c7ea18d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Expression.cs
+++ b/Assets/Scripts/Incidents/Expression.cs
@@ -211,5 +211,11 @@ namespace Game.Incidents
             {"==", (a, b) => ((Location)a).TileIndex == ((Location)b).TileIndex },
             {"!=", (a, b) => ((Location)a).TileIndex != ((Location)b).TileIndex }
         };
+
+        public static Dictionary<string, Func<Type, Type, bool>> TypeComparators = new Dictionary<string, Func<Type, Type, bool>>
+        {
+            {"==", (a, b) => a == b },
+            {"!=", (a, b) => a != b }
+        };
     }
 }

--- a/Assets/Scripts/Incidents/IncidentActionFieldCriteria.cs
+++ b/Assets/Scripts/Incidents/IncidentActionFieldCriteria.cs
@@ -33,6 +33,10 @@ namespace Game.Incidents
 			{
 				evaluator = new ActionFieldIntDictionaryEvaluator(propertyName, ContextType);
 			}
+			else if(PrimitiveType == typeof(List<IIncidentContext>))
+			{
+				evaluator = new ActionFieldListContainsEvaluator(propertyName, ContextType);
+			}
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActionFieldCriteria.cs
+++ b/Assets/Scripts/Incidents/IncidentActionFieldCriteria.cs
@@ -9,7 +9,7 @@ namespace Game.Incidents
 
 		protected override bool IsValidPropertyType(Type type)
 		{
-            return base.IsValidPropertyType(type) || type == typeof(Faction) || type == typeof(Location);
+            return base.IsValidPropertyType(type) || type == typeof(Faction) || type == typeof(Location) || type == typeof(Type);
         }
 
 		protected override void SetPrimitiveType()
@@ -23,6 +23,10 @@ namespace Game.Incidents
 			else if(PrimitiveType == typeof(Location))
 			{
 				evaluator = new LocationEvaluator();
+			}
+			else if(PrimitiveType == typeof(Type))
+			{
+				evaluator = new TypeEvaluator(propertyName, ContextType);
 			}
 		}
 	}

--- a/Assets/Scripts/Incidents/IncidentActionFieldCriteria.cs
+++ b/Assets/Scripts/Incidents/IncidentActionFieldCriteria.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Game.Incidents
 {
@@ -27,6 +28,10 @@ namespace Game.Incidents
 			else if(PrimitiveType == typeof(Type))
 			{
 				evaluator = new TypeEvaluator(propertyName, ContextType);
+			}
+			else if(PrimitiveType == typeof(Dictionary<IIncidentContext, int>))
+			{
+				evaluator = new ActionFieldIntDictionaryEvaluator(propertyName, ContextType);
 			}
 		}
 	}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeFactionRelationsAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeFactionRelationsAction.cs
@@ -5,6 +5,8 @@
 		public ContextualIncidentActionField<Faction> affectedFaction;
 		public ContextualIncidentActionField<Faction> otherFaction;
 		public IntegerRange amount;
+		public bool set;
+		public bool mirrored;
 
 		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
 		{
@@ -17,7 +19,17 @@
 					factionA.FactionRelations.Add(factionB, 0);
 				}
 
-				factionA.FactionRelations[factionB] += amount.Value;
+				factionA.FactionRelations[factionB] = set ? amount : factionA.FactionRelations[factionB] + amount;
+
+				if (mirrored)
+				{
+					if (!factionB.FactionRelations.ContainsKey(factionA))
+					{
+						factionB.FactionRelations.Add(factionA, 0);
+					}
+
+					factionB.FactionRelations[factionA] = set ? amount : factionB.FactionRelations[factionA] + amount;
+				}
 			}
 		}
 	}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeWarStateAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeWarStateAction.cs
@@ -14,6 +14,7 @@
 			{
 				f1.FactionsAtWarWith.Add(f2);
 				f2.FactionsAtWarWith.Add(f1);
+				OutputLogger.Log("War were declared.");
 			}
 			else
 			{
@@ -25,6 +26,8 @@
 				{
 					f2.FactionsAtWarWith.Remove(f1);
 				}
+
+				OutputLogger.Log("War were ended.");
 			}
 		}
 	}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateAction.cs
@@ -5,6 +5,7 @@ namespace Game.Incidents
 	abstract public class GetOrCreateAction<T> : GenericIncidentAction where T : IIncidentContext
 	{
 		public bool findFirst = true;
+		public bool allowCreate = true;
 
 		[ShowIf("@this.findFirst")]
 		public ContextualIncidentActionField<T> valueToFind;
@@ -14,7 +15,7 @@ namespace Game.Incidents
 
 		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
 		{
-			if(!findFirst || valueToFind.GetTypedFieldValue() == null)
+			if(!findFirst || (valueToFind.GetTypedFieldValue() == null && allowCreate))
 			{
 				MakeNew();
 			}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateCityAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateCityAction.cs
@@ -1,12 +1,17 @@
 ﻿using Game.Simulation;
+using Sirenix.OdinInspector;
 
 namespace Game.Incidents
 {
 	public class GetOrCreateCityAction : GetOrCreateAction<City>
 	{
+		[ShowIf("@this.allowCreate")]
 		public ContextualIncidentActionField<Faction> faction;
+		[ShowIf("@this.allowCreate")]
 		public LocationActionField location;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange population;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange wealth;
 		protected override void MakeNew()
 		{

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateFactionAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateFactionAction.cs
@@ -1,15 +1,23 @@
 ﻿using Game.Simulation;
+using Sirenix.OdinInspector;
 
 namespace Game.Incidents
 {
 	public class GetOrCreateFactionAction : GetOrCreateAction<Faction>
 	{
+        [ShowIf("@this.allowCreate")]
         public IntegerRange population;
+        [ShowIf("@this.allowCreate")]
         public IntegerRange influence;
+        [ShowIf("@this.allowCreate")]
         public IntegerRange wealth;
+        [ShowIf("@this.allowCreate")]
         public IntegerRange politicalPriority;
+        [ShowIf("@this.allowCreate")]
         public IntegerRange economicPriority;
+        [ShowIf("@this.allowCreate")]
         public IntegerRange religiousPriority;
+        [ShowIf("@this.allowCreate")]
         public IntegerRange militaryPriority;
 
 		protected override void MakeNew()

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateItemAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateItemAction.cs
@@ -9,7 +9,7 @@ namespace Game.Incidents
 {
 	public class GetOrCreateItemAction : GetOrCreateAction<Item>
 	{
-		[ValueDropdown("GetFilteredTypeList")]
+		[ValueDropdown("GetFilteredTypeList"), ShowIf("@this.allowCreate")]
 		public Type itemType;
 
 		protected override void MakeNew()

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateLandmarkAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateLandmarkAction.cs
@@ -1,10 +1,12 @@
 ﻿using Game.Simulation;
+using Sirenix.OdinInspector;
 using System;
 
 namespace Game.Incidents
 {
 	public class GetOrCreateLandmarkAction : GetOrCreateAction<Landmark>
 	{
+		[ShowIf("@this.allowCreate")]
 		public LocationActionField location;
 
 		protected override void MakeNew()

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreatePersonAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreatePersonAction.cs
@@ -1,27 +1,45 @@
 ﻿using Game.Enums;
 using Game.Simulation;
+using Sirenix.OdinInspector;
 using System.Collections.Generic;
 
 namespace Game.Incidents
 {
 	public class GetOrCreatePersonAction : GetOrCreateAction<Person>
 	{
+		[ShowIf("@this.allowCreate")]
 		public ContextualIncidentActionField<Person> parent;
+		[ShowIf("@this.allowCreate")]
 		public ContextualIncidentActionField<Race> race;
+		[ShowIf("@this.allowCreate")]
 		public ContextualIncidentActionField<Faction> faction;
+		[ShowIf("@this.allowCreate")]
 		public Gender gender;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange age;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange politicalPriority;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange economicPriority;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange religiousPriority;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange militaryPriority;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange influence;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange wealth;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange strength;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange dexterity;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange constitution;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange intelligence;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange wisdom;
+		[ShowIf("@this.allowCreate")]
 		public IntegerRange charisma;
 
 		protected override void MakeNew()

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateSpecialFactionAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateSpecialFactionAction.cs
@@ -8,9 +8,11 @@ namespace Game.Incidents
 {
 	public class GetOrCreateSpecialFactionAction : GetOrCreateFactionAction
 	{
-		protected override void MakeNew()
+        [ValueDropdown("GetFilteredTypeList"), LabelText("Special Faction Type")]
+        public Type factionType;
+        protected override void MakeNew()
 		{
-            var specialFactionType = SpecialFaction.CalculateFactionType(politicalPriority, economicPriority, religiousPriority, militaryPriority);
+            var specialFactionType = factionType == null ? SpecialFaction.CalculateFactionType(politicalPriority, economicPriority, religiousPriority, militaryPriority) : factionType;
             var specialFaction = (Faction)Activator.CreateInstance(specialFactionType);
             specialFaction.Population = population;
             specialFaction.Influence = influence;

--- a/Assets/Scripts/Incidents/IncidentEditorWindow.cs
+++ b/Assets/Scripts/Incidents/IncidentEditorWindow.cs
@@ -51,7 +51,7 @@ namespace Game.Incidents
         [ShowIfGroup("ContextTypeChosen")]
         public string incidentName;
 
-        [Range(0, 10), ShowIfGroup("ContextTypeChosen")]
+        [Range(0, 20), ShowIfGroup("ContextTypeChosen")]
         public int weight;
 
         [ShowIfGroup("ContextTypeChosen"), ListDrawerSettings(CustomAddFunction = "AddNewCriteriaItem"), HideReferenceObjectPicker]


### PR DESCRIPTION
I've been working through testing out incident actions and combinations, which is a bit of a slog, but it's helping me determine which pieces are still missing. I'm not going to go into too much depth this time, but in short I added functionality to:
- Choose Get or Create or both for all GetOrCreate actions
- Ability to compare types when comparing for criteria
- Get values from collections for criteria/running actions
- Ability to check for existence of items
- other stuff??

What I've realized i need, and the whole reason for cutting this PR off here, is that for deployed contexts, theres no way of grabbing the info out of them to then use as part of the follow up incident. So in the case of a Faction context starting an incident, the system knows that that Faction context will be {0}, and we can grab it and use it etc. But we dont have a way to assign IDs to sub contexts within the deployed context, such as a pair of factions in a battle context, so we can't use those contexts in a meaningful way. So thats the next project.