### PR TITLE
12-04-2022 Battle Incidents

### DIFF
--- a/Assets/Resources/IncidentData/Faction Expand Territory Over Time.json
+++ b/Assets/Resources/IncidentData/Faction Expand Territory Over Time.json
@@ -46,7 +46,7 @@
                     "min": 0,
                     "max": 20,
                     "constant": 0,
-                    "Value": 15,
+                    "Value": 14,
                     "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
                   "subexpressions": null,
@@ -70,7 +70,7 @@
                     "min": 0,
                     "max": 20,
                     "constant": 0,
-                    "Value": 1,
+                    "Value": 15,
                     "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
                   "subexpressions": null,
@@ -166,7 +166,7 @@
                             "min": 0,
                             "max": 20,
                             "constant": 0,
-                            "Value": 19,
+                            "Value": 3,
                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                           },
                           "subexpressions": null,
@@ -190,7 +190,7 @@
                             "min": 0,
                             "max": 20,
                             "constant": 0,
-                            "Value": 5,
+                            "Value": 8,
                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                           },
                           "subexpressions": null,
@@ -201,6 +201,7 @@
                         }
                       ]
                     },
+                    "clamped": true,
                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                     "ID": 2,

--- a/Assets/Resources/IncidentData/Faction Expand Territory Over Time.json
+++ b/Assets/Resources/IncidentData/Faction Expand Territory Over Time.json
@@ -3,19 +3,28 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Faction Expand Territory Over Time",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 17,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 17,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "3",
+          "$id": "4",
           "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
           "propertyName": "Influence",
           "evaluator": {
-            "$id": "4",
+            "$id": "5",
             "$type": "Game.Incidents.IntegerEvaluator, Assembly-CSharp",
             "propertyName": "Influence",
             "Comparator": ">=",
@@ -23,7 +32,7 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "5",
+                  "$id": "6",
                   "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                   "hasNextOperator": true,
                   "ExpressionType": 2,
@@ -31,7 +40,7 @@
                   "chosenMethod": null,
                   "chosenProperty": "ControlledTiles",
                   "range": {
-                    "$id": "6",
+                    "$id": "7",
                     "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                     "randomRange": true,
                     "min": 0,
@@ -40,12 +49,14 @@
                     "Value": 15,
                     "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
                   "rangeWarning": "Range not implemented for non integers!",
                   "nextOperator": "^",
                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                 },
                 {
-                  "$id": "7",
+                  "$id": "8",
                   "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                   "hasNextOperator": false,
                   "ExpressionType": 0,
@@ -53,7 +64,7 @@
                   "chosenMethod": null,
                   "chosenProperty": null,
                   "range": {
-                    "$id": "8",
+                    "$id": "9",
                     "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                     "randomRange": true,
                     "min": 0,
@@ -62,6 +73,8 @@
                     "Value": 1,
                     "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
                   "rangeWarning": "Range not implemented for non integers!",
                   "nextOperator": null,
                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
@@ -79,30 +92,30 @@
     }
   },
   "ActionContainer": {
-    "$id": "9",
+    "$id": "10",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": "{0} expanded borders.",
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "10",
+          "$id": "11",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "11",
+            "$id": "12",
             "$type": "Game.Incidents.ExpandBordersAction, Assembly-CSharp",
             "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
             "Context": null
           }
         },
         {
-          "$id": "12",
+          "$id": "13",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "13",
+            "$id": "14",
             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
             "contextToModify": {
-              "$id": "14",
+              "$id": "15",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -125,11 +138,13 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "15",
+                  "$id": "16",
                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                   "propertyName": "Influence",
-                  "calculator": {
-                    "$id": "16",
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                  "Calculator": {
+                    "$id": "17",
                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                     "propertyName": "Influence",
                     "Operation": "-",
@@ -137,7 +152,7 @@
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "17",
+                          "$id": "18",
                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                           "hasNextOperator": true,
                           "ExpressionType": 2,
@@ -145,7 +160,7 @@
                           "chosenMethod": null,
                           "chosenProperty": "ControlledTiles",
                           "range": {
-                            "$id": "18",
+                            "$id": "19",
                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                             "randomRange": true,
                             "min": 0,
@@ -154,12 +169,14 @@
                             "Value": 19,
                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                           },
+                          "subexpressions": null,
+                          "previousCalculatedID": null,
                           "rangeWarning": "Range not implemented for non integers!",
                           "nextOperator": "^",
                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                         },
                         {
-                          "$id": "19",
+                          "$id": "20",
                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                           "hasNextOperator": false,
                           "ExpressionType": 0,
@@ -167,7 +184,7 @@
                           "chosenMethod": null,
                           "chosenProperty": null,
                           "range": {
-                            "$id": "20",
+                            "$id": "21",
                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                             "randomRange": true,
                             "min": 0,
@@ -176,18 +193,20 @@
                             "Value": 5,
                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                           },
+                          "subexpressions": null,
+                          "previousCalculatedID": null,
                           "rangeWarning": "Range not implemented for non integers!",
                           "nextOperator": null,
                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                         }
                       ]
                     },
-                    "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "ID": 2,
+                    "NameID": "{EX 2}",
                     "AllowMultipleExpressions": true
-                  },
-                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  }
                 }
               ]
             }

--- a/Assets/Resources/IncidentData/Test_Battle_CitySiege.json
+++ b/Assets/Resources/IncidentData/Test_Battle_CitySiege.json
@@ -62,7 +62,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 2,
+              "Value": 15,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "wealth": {
@@ -72,7 +72,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 9,
+              "Value": 1,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "findFirst": true,
@@ -116,8 +116,7 @@
                           "NameID": null,
                           "ActionFieldIDString": "None",
                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                        },
-                        "onSetContextType": null
+                        }
                       },
                       "propertyName": "AffiliatedFaction",
                       "Comparator": "==",
@@ -197,26 +196,84 @@
                   "weightModifier": {
                     "$id": "22",
                     "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
-                    "advancedMode": false,
+                    "advancedMode": true,
                     "baseWeight": 5,
-                    "container": null,
-                    "weight": null
+                    "container": {
+                      "$id": "23",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "actionField": {
+                        "$id": "24",
+                        "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                        "parentType": null,
+                        "AllowSelf": false,
+                        "AllowNull": false,
+                        "criteria": {
+                          "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                          "$values": []
+                        },
+                        "previousField": "{2}:FactionBattleContext:defender",
+                        "previousFieldID": 2,
+                        "value": null,
+                        "delayedValue": null,
+                        "Method": 1,
+                        "ActionFieldID": 0,
+                        "NameID": null,
+                        "ActionFieldIDString": "None",
+                        "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                      }
+                    },
+                    "weight": {
+                      "$id": "25",
+                      "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                      "baseWeight": 5,
+                      "Operation": "+",
+                      "expressions": {
+                        "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                        "$values": [
+                          {
+                            "$id": "26",
+                            "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": false,
+                            "ExpressionType": 2,
+                            "constValue": 0,
+                            "chosenMethod": null,
+                            "chosenProperty": "MilitaryPower",
+                            "range": {
+                              "$id": "27",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 19,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": null,
+                            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          }
+                        ]
+                      }
+                    }
                   },
                   "actionHandler": {
-                    "$id": "23",
+                    "$id": "28",
                     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
                     "incidentLog": "{2} successfully defends {4}, repelling {1}'s invading force.",
                     "Actions": {
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "24",
+                          "$id": "29",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "25",
+                            "$id": "30",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "26",
+                              "$id": "31",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -239,13 +296,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "27",
+                                  "$id": "32",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "28",
+                                    "$id": "33",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "=",
@@ -253,7 +310,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "29",
+                                          "$id": "34",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -261,31 +318,7 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "30",
-                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-                                            "randomRange": true,
-                                            "min": 0,
-                                            "max": 20,
-                                            "constant": 0,
-                                            "Value": 18,
-                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-                                          },
-                                          "subexpressions": null,
-                                          "previousCalculatedID": null,
-                                          "rangeWarning": "Range not implemented for non integers!",
-                                          "nextOperator": "*",
-                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                                        },
-                                        {
-                                          "$id": "31",
-                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
-                                          "hasNextOperator": true,
-                                          "ExpressionType": 0,
-                                          "constValue": 4,
-                                          "chosenMethod": null,
-                                          "chosenProperty": null,
-                                          "range": {
-                                            "$id": "32",
+                                            "$id": "35",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
@@ -297,11 +330,35 @@
                                           "subexpressions": null,
                                           "previousCalculatedID": null,
                                           "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "*",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "36",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 0,
+                                          "constValue": 4,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "37",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 7,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
                                           "nextOperator": "/",
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "33",
+                                          "$id": "38",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 0,
@@ -309,13 +366,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "34",
+                                            "$id": "39",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 8,
+                                            "Value": 17,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -338,13 +395,13 @@
                           }
                         },
                         {
-                          "$id": "35",
+                          "$id": "40",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "36",
+                            "$id": "41",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "37",
+                              "$id": "42",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -367,13 +424,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "38",
+                                  "$id": "43",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "39",
+                                    "$id": "44",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "=",
@@ -381,7 +438,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "40",
+                                          "$id": "45",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -389,13 +446,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "41",
+                                            "$id": "46",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 12,
+                                            "Value": 16,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -405,7 +462,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "42",
+                                          "$id": "47",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 0,
@@ -413,13 +470,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "43",
+                                            "$id": "48",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 13,
+                                            "Value": 1,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -429,7 +486,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "44",
+                                          "$id": "49",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 0,
@@ -437,13 +494,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "45",
+                                            "$id": "50",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 13,
+                                            "Value": 10,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -476,10 +533,10 @@
                   "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                 },
                 {
-                  "$id": "46",
+                  "$id": "51",
                   "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
                   "weightModifier": {
-                    "$id": "47",
+                    "$id": "52",
                     "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
                     "advancedMode": false,
                     "baseWeight": 1,
@@ -487,20 +544,20 @@
                     "weight": null
                   },
                   "actionHandler": {
-                    "$id": "48",
+                    "$id": "53",
                     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
                     "incidentLog": "{1} captures {4}.",
                     "Actions": {
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "49",
+                          "$id": "54",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "50",
+                            "$id": "55",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "51",
+                              "$id": "56",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -523,13 +580,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "52",
+                                  "$id": "57",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "53",
+                                    "$id": "58",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "=",
@@ -537,7 +594,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "54",
+                                          "$id": "59",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -545,13 +602,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "55",
+                                            "$id": "60",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 12,
+                                            "Value": 14,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -561,7 +618,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "56",
+                                          "$id": "61",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 0,
@@ -569,13 +626,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "57",
+                                            "$id": "62",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 0,
+                                            "Value": 2,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -585,7 +642,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "58",
+                                          "$id": "63",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 0,
@@ -593,13 +650,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "59",
+                                            "$id": "64",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 14,
+                                            "Value": 6,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -622,13 +679,13 @@
                           }
                         },
                         {
-                          "$id": "60",
+                          "$id": "65",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "61",
+                            "$id": "66",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "62",
+                              "$id": "67",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -651,13 +708,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "63",
+                                  "$id": "68",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "64",
+                                    "$id": "69",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "-",
@@ -665,7 +722,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "65",
+                                          "$id": "70",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -673,13 +730,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "66",
+                                            "$id": "71",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 14,
+                                            "Value": 1,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -689,7 +746,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "67",
+                                          "$id": "72",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 4,
@@ -697,20 +754,20 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "NumCities",
                                           "range": {
-                                            "$id": "68",
+                                            "$id": "73",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 15,
+                                            "Value": 7,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": {
                                             "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                             "$values": [
                                               {
-                                                "$id": "69",
+                                                "$id": "74",
                                                 "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                                 "hasNextOperator": true,
                                                 "ExpressionType": 2,
@@ -718,13 +775,13 @@
                                                 "chosenMethod": null,
                                                 "chosenProperty": "NumCities",
                                                 "range": {
-                                                  "$id": "70",
+                                                  "$id": "75",
                                                   "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                                   "randomRange": true,
                                                   "min": 0,
                                                   "max": 20,
                                                   "constant": 0,
-                                                  "Value": 3,
+                                                  "Value": 5,
                                                   "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                                 },
                                                 "subexpressions": null,
@@ -734,7 +791,7 @@
                                                 "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                               },
                                               {
-                                                "$id": "71",
+                                                "$id": "76",
                                                 "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                                 "hasNextOperator": false,
                                                 "ExpressionType": 0,
@@ -742,13 +799,13 @@
                                                 "chosenMethod": null,
                                                 "chosenProperty": null,
                                                 "range": {
-                                                  "$id": "72",
+                                                  "$id": "77",
                                                   "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                                   "randomRange": true,
                                                   "min": 0,
                                                   "max": 20,
                                                   "constant": 0,
-                                                  "Value": 8,
+                                                  "Value": 2,
                                                   "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                                 },
                                                 "subexpressions": null,
@@ -778,13 +835,13 @@
                           }
                         },
                         {
-                          "$id": "73",
+                          "$id": "78",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "74",
+                            "$id": "79",
                             "$type": "Game.Incidents.ChangeControlOfCityAction, Assembly-CSharp",
                             "cityGainer": {
-                              "$id": "75",
+                              "$id": "80",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -804,7 +861,7 @@
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "cityLoser": {
-                              "$id": "76",
+                              "$id": "81",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -824,7 +881,7 @@
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "city": {
-                              "$id": "77",
+                              "$id": "82",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -856,10 +913,10 @@
                   "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                 },
                 {
-                  "$id": "78",
+                  "$id": "83",
                   "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
                   "weightModifier": {
-                    "$id": "79",
+                    "$id": "84",
                     "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
                     "advancedMode": false,
                     "baseWeight": 2,
@@ -867,24 +924,24 @@
                     "weight": null
                   },
                   "actionHandler": {
-                    "$id": "80",
+                    "$id": "85",
                     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
                     "incidentLog": "{1} raiders loot and pillage {4}.",
                     "Actions": {
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "81",
+                          "$id": "86",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "82",
+                            "$id": "87",
                             "$type": "Game.Incidents.TradeItemsAction, Assembly-CSharp",
                             "givingInventory": {
-                              "$id": "83",
+                              "$id": "88",
                               "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
                               "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "actionField": {
-                                "$id": "84",
+                                "$id": "89",
                                 "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                                 "parentType": null,
                                 "AllowSelf": false,
@@ -902,15 +959,14 @@
                                 "NameID": "{16}:TradeItemsAction:givingInventory",
                                 "ActionFieldIDString": "{16}",
                                 "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                              },
-                              "onSetContextType": null
+                              }
                             },
                             "receivingInventory": {
-                              "$id": "85",
+                              "$id": "90",
                               "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
                               "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "actionField": {
-                                "$id": "86",
+                                "$id": "91",
                                 "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                                 "parentType": null,
                                 "AllowSelf": false,
@@ -919,18 +975,18 @@
                                   "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
                                   "$values": [
                                     {
-                                      "$id": "87",
+                                      "$id": "92",
                                       "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                                       "propertyName": "AffiliatedFaction",
                                       "evaluator": {
-                                        "$id": "88",
+                                        "$id": "93",
                                         "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
                                         "compareTo": {
-                                          "$id": "89",
+                                          "$id": "94",
                                           "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
                                           "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                           "actionField": {
-                                            "$id": "90",
+                                            "$id": "95",
                                             "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                             "parentType": null,
                                             "AllowSelf": false,
@@ -948,8 +1004,7 @@
                                             "NameID": null,
                                             "ActionFieldIDString": "None",
                                             "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                                          },
-                                          "onSetContextType": null
+                                          }
                                         },
                                         "propertyName": "AffiliatedFaction",
                                         "Comparator": "==",
@@ -970,19 +1025,18 @@
                                 "NameID": "{17}:TradeItemsAction:receivingInventory",
                                 "ActionFieldIDString": "{17}",
                                 "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                              },
-                              "onSetContextType": null
+                              }
                             }
                           }
                         },
                         {
-                          "$id": "91",
+                          "$id": "96",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "92",
+                            "$id": "97",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "93",
+                              "$id": "98",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1005,13 +1059,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "94",
+                                  "$id": "99",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "Wealth",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "95",
+                                    "$id": "100",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "Wealth",
                                     "Operation": "-",
@@ -1019,7 +1073,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "96",
+                                          "$id": "101",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -1027,13 +1081,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "Wealth",
                                           "range": {
-                                            "$id": "97",
+                                            "$id": "102",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 3,
+                                            "Value": 17,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1043,7 +1097,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "98",
+                                          "$id": "103",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 2,
@@ -1051,13 +1105,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "NumCities",
                                           "range": {
-                                            "$id": "99",
+                                            "$id": "104",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 2,
+                                            "Value": 15,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1080,13 +1134,13 @@
                           }
                         },
                         {
-                          "$id": "100",
+                          "$id": "105",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "101",
+                            "$id": "106",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "102",
+                              "$id": "107",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1109,13 +1163,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "103",
+                                  "$id": "108",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "Wealth",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "104",
+                                    "$id": "109",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "Wealth",
                                     "Operation": "+",
@@ -1123,7 +1177,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "105",
+                                          "$id": "110",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 5,
@@ -1131,13 +1185,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "106",
+                                            "$id": "111",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 9,
+                                            "Value": 10,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1170,10 +1224,10 @@
                   "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                 },
                 {
-                  "$id": "107",
+                  "$id": "112",
                   "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
                   "weightModifier": {
-                    "$id": "108",
+                    "$id": "113",
                     "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
                     "advancedMode": false,
                     "baseWeight": 1,
@@ -1181,20 +1235,20 @@
                     "weight": null
                   },
                   "actionHandler": {
-                    "$id": "109",
+                    "$id": "114",
                     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
                     "incidentLog": null,
                     "Actions": {
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "110",
+                          "$id": "115",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "111",
+                            "$id": "116",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "112",
+                              "$id": "117",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1217,13 +1271,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "113",
+                                  "$id": "118",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "Wealth",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "114",
+                                    "$id": "119",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "Wealth",
                                     "Operation": "-",
@@ -1231,7 +1285,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "115",
+                                          "$id": "120",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -1239,13 +1293,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "Wealth",
                                           "range": {
-                                            "$id": "116",
+                                            "$id": "121",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 17,
+                                            "Value": 0,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1255,7 +1309,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "117",
+                                          "$id": "122",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 2,
@@ -1263,13 +1317,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "NumCities",
                                           "range": {
-                                            "$id": "118",
+                                            "$id": "123",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 11,
+                                            "Value": 19,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1288,13 +1342,13 @@
                                   }
                                 },
                                 {
-                                  "$id": "119",
+                                  "$id": "124",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "120",
+                                    "$id": "125",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "-",
@@ -1302,7 +1356,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "121",
+                                          "$id": "126",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -1310,13 +1364,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "122",
+                                            "$id": "127",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 1,
+                                            "Value": 15,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1326,7 +1380,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "123",
+                                          "$id": "128",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 2,
@@ -1334,13 +1388,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "NumCities",
                                           "range": {
-                                            "$id": "124",
+                                            "$id": "129",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 5,
+                                            "Value": 13,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1363,13 +1417,13 @@
                           }
                         },
                         {
-                          "$id": "125",
+                          "$id": "130",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "126",
+                            "$id": "131",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "127",
+                              "$id": "132",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1392,13 +1446,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "128",
+                                  "$id": "133",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "129",
+                                    "$id": "134",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "-",
@@ -1406,7 +1460,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "130",
+                                          "$id": "135",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 5,
@@ -1414,13 +1468,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "131",
+                                            "$id": "136",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 11,
+                                            "Value": 2,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1443,13 +1497,13 @@
                           }
                         },
                         {
-                          "$id": "132",
+                          "$id": "137",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "133",
+                            "$id": "138",
                             "$type": "Game.Incidents.DestroyCityAction, Assembly-CSharp",
                             "city": {
-                              "$id": "134",
+                              "$id": "139",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,

--- a/Assets/Resources/IncidentData/Test_Battle_CitySiege.json
+++ b/Assets/Resources/IncidentData/Test_Battle_CitySiege.json
@@ -104,7 +104,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 11,
+              "Value": 15,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "wealth": {
@@ -288,7 +288,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 10,
+                              "Value": 19,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -366,7 +366,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 17,
+                                            "Value": 5,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -390,7 +390,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 3,
+                                            "Value": 7,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -414,7 +414,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 14,
+                                            "Value": 17,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -425,6 +425,7 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                     "ID": 7,
@@ -494,7 +495,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 13,
+                                            "Value": 16,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -518,7 +519,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 6,
+                                            "Value": 1,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -542,7 +543,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 8,
+                                            "Value": 10,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -553,6 +554,7 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                     "ID": 9,
@@ -630,7 +632,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 1,
+                              "Value": 14,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -654,7 +656,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 10,
+                              "Value": 2,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -732,7 +734,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 10,
+                                            "Value": 6,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -756,7 +758,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 3,
+                                            "Value": 1,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -780,7 +782,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 12,
+                                            "Value": 7,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -791,6 +793,7 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                     "ID": 11,
@@ -860,7 +863,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 12,
+                                            "Value": 5,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -884,7 +887,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 1,
+                                            "Value": 2,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": {
@@ -905,7 +908,7 @@
                                                   "min": 0,
                                                   "max": 20,
                                                   "constant": 0,
-                                                  "Value": 2,
+                                                  "Value": 17,
                                                   "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                                 },
                                                 "subexpressions": null,
@@ -929,7 +932,7 @@
                                                   "min": 0,
                                                   "max": 20,
                                                   "constant": 0,
-                                                  "Value": 9,
+                                                  "Value": 15,
                                                   "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                                 },
                                                 "subexpressions": null,
@@ -947,6 +950,7 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                     "ID": 13,
@@ -1092,7 +1096,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 15,
+                              "Value": 10,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -1116,7 +1120,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 2,
+                              "Value": 0,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -1194,7 +1198,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 3,
+                                            "Value": 19,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1218,7 +1222,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 11,
+                                            "Value": 15,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1229,10 +1233,83 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                     "ID": 18,
                                     "NameID": "{EX 18}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                },
+                                {
+                                  "$id": "111",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "112",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "113",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "114",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 13,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "115",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "116",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 5,
+                                            "max": 10,
+                                            "constant": 0,
+                                            "Value": 5,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "clamped": true,
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 19,
+                                    "NameID": "{EX 19}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -1241,13 +1318,13 @@
                           }
                         },
                         {
-                          "$id": "111",
+                          "$id": "117",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "112",
+                            "$id": "118",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "113",
+                              "$id": "119",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1261,22 +1338,22 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 19,
-                              "NameID": "{19}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{19}",
+                              "ActionFieldID": 20,
+                              "NameID": "{20}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{20}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "114",
+                                  "$id": "120",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "Wealth",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "115",
+                                    "$id": "121",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "Wealth",
                                     "Operation": "+",
@@ -1284,7 +1361,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "116",
+                                          "$id": "122",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 5,
@@ -1292,27 +1369,100 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "117",
+                                            "$id": "123",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 11,
+                                            "Value": 9,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
-                                          "previousCalculatedID": "{EX 19}",
+                                          "previousCalculatedID": "{EX 18}",
                                           "rangeWarning": "Range not implemented for non integers!",
                                           "nextOperator": null,
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 20,
-                                    "NameID": "{EX 20}",
+                                    "ID": 21,
+                                    "NameID": "{EX 21}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                },
+                                {
+                                  "$id": "124",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "125",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "126",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "127",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 18,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "128",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "129",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 8,
+                                            "max": 11,
+                                            "constant": 0,
+                                            "Value": 8,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "clamped": true,
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 22,
+                                    "NameID": "{EX 22}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -1321,17 +1471,17 @@
                           }
                         },
                         {
-                          "$id": "118",
+                          "$id": "130",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "119",
+                            "$id": "131",
                             "$type": "Game.Incidents.TradeAllItemsAction, Assembly-CSharp",
                             "givingInventory": {
-                              "$id": "120",
+                              "$id": "132",
                               "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
                               "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "actionField": {
-                                "$id": "121",
+                                "$id": "133",
                                 "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                                 "parentType": null,
                                 "AllowSelf": false,
@@ -1345,18 +1495,18 @@
                                 "value": null,
                                 "delayedValue": null,
                                 "Method": 1,
-                                "ActionFieldID": 21,
-                                "NameID": "{21}:TradeAllItemsAction:givingInventory",
-                                "ActionFieldIDString": "{21}",
+                                "ActionFieldID": 23,
+                                "NameID": "{23}:TradeAllItemsAction:givingInventory",
+                                "ActionFieldIDString": "{23}",
                                 "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                               }
                             },
                             "receivingInventory": {
-                              "$id": "122",
+                              "$id": "134",
                               "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
                               "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "actionField": {
-                                "$id": "123",
+                                "$id": "135",
                                 "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                                 "parentType": null,
                                 "AllowSelf": false,
@@ -1365,18 +1515,18 @@
                                   "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
                                   "$values": [
                                     {
-                                      "$id": "124",
+                                      "$id": "136",
                                       "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                                       "propertyName": "AffiliatedFaction",
                                       "evaluator": {
-                                        "$id": "125",
+                                        "$id": "137",
                                         "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
                                         "compareTo": {
-                                          "$id": "126",
+                                          "$id": "138",
                                           "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
                                           "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                           "actionField": {
-                                            "$id": "127",
+                                            "$id": "139",
                                             "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                             "parentType": null,
                                             "AllowSelf": false,
@@ -1411,9 +1561,9 @@
                                 "value": null,
                                 "delayedValue": null,
                                 "Method": 0,
-                                "ActionFieldID": 22,
-                                "NameID": "{22}:TradeAllItemsAction:receivingInventory",
-                                "ActionFieldIDString": "{22}",
+                                "ActionFieldID": 24,
+                                "NameID": "{24}:TradeAllItemsAction:receivingInventory",
+                                "ActionFieldIDString": "{24}",
                                 "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                               }
                             }
@@ -1430,19 +1580,19 @@
                   "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                 },
                 {
-                  "$id": "128",
+                  "$id": "140",
                   "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
                   "weightModifier": {
-                    "$id": "129",
+                    "$id": "141",
                     "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
                     "advancedMode": true,
                     "baseWeight": 1,
                     "container": {
-                      "$id": "130",
+                      "$id": "142",
                       "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
                       "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                       "actionField": {
-                        "$id": "131",
+                        "$id": "143",
                         "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                         "parentType": null,
                         "AllowSelf": false,
@@ -1463,7 +1613,7 @@
                       }
                     },
                     "weight": {
-                      "$id": "132",
+                      "$id": "144",
                       "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                       "baseWeight": 1,
                       "Operation": "=",
@@ -1471,7 +1621,7 @@
                         "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                         "$values": [
                           {
-                            "$id": "133",
+                            "$id": "145",
                             "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                             "hasNextOperator": true,
                             "ExpressionType": 2,
@@ -1479,13 +1629,13 @@
                             "chosenMethod": null,
                             "chosenProperty": "MilitaryPower",
                             "range": {
-                              "$id": "134",
+                              "$id": "146",
                               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                               "randomRange": true,
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 1,
+                              "Value": 8,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -1495,7 +1645,7 @@
                             "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                           },
                           {
-                            "$id": "135",
+                            "$id": "147",
                             "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                             "hasNextOperator": false,
                             "ExpressionType": 0,
@@ -1503,13 +1653,13 @@
                             "chosenMethod": null,
                             "chosenProperty": null,
                             "range": {
-                              "$id": "136",
+                              "$id": "148",
                               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                               "randomRange": true,
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 18,
+                              "Value": 12,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -1523,20 +1673,20 @@
                     }
                   },
                   "actionHandler": {
-                    "$id": "137",
+                    "$id": "149",
                     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
                     "incidentLog": null,
                     "Actions": {
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "138",
+                          "$id": "150",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "139",
+                            "$id": "151",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "140",
+                              "$id": "152",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1550,22 +1700,22 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 23,
-                              "NameID": "{23}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{23}",
+                              "ActionFieldID": 25,
+                              "NameID": "{25}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{25}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "141",
+                                  "$id": "153",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "Wealth",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "142",
+                                    "$id": "154",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "Wealth",
                                     "Operation": "-",
@@ -1573,7 +1723,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "143",
+                                          "$id": "155",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -1581,13 +1731,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "Wealth",
                                           "range": {
-                                            "$id": "144",
+                                            "$id": "156",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 2,
+                                            "Value": 13,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1597,7 +1747,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "145",
+                                          "$id": "157",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 2,
@@ -1605,13 +1755,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "NumCities",
                                           "range": {
-                                            "$id": "146",
+                                            "$id": "158",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 14,
+                                            "Value": 13,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1622,21 +1772,22 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 24,
-                                    "NameID": "{EX 24}",
+                                    "ID": 26,
+                                    "NameID": "{EX 26}",
                                     "AllowMultipleExpressions": true
                                   }
                                 },
                                 {
-                                  "$id": "147",
+                                  "$id": "159",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "148",
+                                    "$id": "160",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "-",
@@ -1644,7 +1795,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "149",
+                                          "$id": "161",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -1652,31 +1803,7 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "150",
-                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-                                            "randomRange": true,
-                                            "min": 0,
-                                            "max": 20,
-                                            "constant": 0,
-                                            "Value": 16,
-                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-                                          },
-                                          "subexpressions": null,
-                                          "previousCalculatedID": null,
-                                          "rangeWarning": "Range not implemented for non integers!",
-                                          "nextOperator": "/",
-                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                                        },
-                                        {
-                                          "$id": "151",
-                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
-                                          "hasNextOperator": false,
-                                          "ExpressionType": 2,
-                                          "constValue": 0,
-                                          "chosenMethod": null,
-                                          "chosenProperty": "NumCities",
-                                          "range": {
-                                            "$id": "152",
+                                            "$id": "162",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
@@ -1688,15 +1815,40 @@
                                           "subexpressions": null,
                                           "previousCalculatedID": null,
                                           "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "163",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "NumCities",
+                                          "range": {
+                                            "$id": "164",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 0,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
                                           "nextOperator": null,
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 25,
-                                    "NameID": "{EX 25}",
+                                    "ID": 27,
+                                    "NameID": "{EX 27}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -1705,13 +1857,13 @@
                           }
                         },
                         {
-                          "$id": "153",
+                          "$id": "165",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "154",
+                            "$id": "166",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "155",
+                              "$id": "167",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1725,22 +1877,22 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 26,
-                              "NameID": "{26}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{26}",
+                              "ActionFieldID": 28,
+                              "NameID": "{28}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{28}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "156",
+                                  "$id": "168",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "157",
+                                    "$id": "169",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "-",
@@ -1748,7 +1900,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "158",
+                                          "$id": "170",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 5,
@@ -1756,27 +1908,28 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "159",
+                                            "$id": "171",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 1,
+                                            "Value": 14,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
-                                          "previousCalculatedID": "{EX 24}",
+                                          "previousCalculatedID": "{EX 26}",
                                           "rangeWarning": "Range not implemented for non integers!",
                                           "nextOperator": null,
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 27,
-                                    "NameID": "{EX 27}",
+                                    "ID": 29,
+                                    "NameID": "{EX 29}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -1785,13 +1938,13 @@
                           }
                         },
                         {
-                          "$id": "160",
+                          "$id": "172",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "161",
+                            "$id": "173",
                             "$type": "Game.Incidents.DestroyCityAction, Assembly-CSharp",
                             "city": {
-                              "$id": "162",
+                              "$id": "174",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1805,9 +1958,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 28,
-                              "NameID": "{28}:DestroyCityAction:city",
-                              "ActionFieldIDString": "{28}",
+                              "ActionFieldID": 30,
+                              "NameID": "{30}:DestroyCityAction:city",
+                              "ActionFieldIDString": "{30}",
                               "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             }
                           }

--- a/Assets/Resources/IncidentData/Test_Battle_CitySiege.json
+++ b/Assets/Resources/IncidentData/Test_Battle_CitySiege.json
@@ -92,9 +92,9 @@
               "LocationFindMethod": 0,
               "FactionCellLocationMethod": 0,
               "Method": 0,
-              "ActionFieldID": 0,
-              "NameID": null,
-              "ActionFieldIDString": "None",
+              "ActionFieldID": 5,
+              "NameID": "{5}:GetOrCreateCityAction:location",
+              "ActionFieldIDString": "{5}",
               "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "population": {
@@ -104,7 +104,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 13,
+              "Value": 11,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "wealth": {
@@ -114,11 +114,11 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 5,
+              "Value": 1,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "findFirst": true,
-            "allowCreate": true,
+            "allowCreate": false,
             "actionField": {
               "$id": "12",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
@@ -288,7 +288,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 18,
+                              "Value": 10,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -329,9 +329,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 5,
-                              "NameID": "{5}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{5}",
+                              "ActionFieldID": 6,
+                              "NameID": "{6}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{6}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
@@ -366,7 +366,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 0,
+                                            "Value": 17,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -390,7 +390,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 15,
+                                            "Value": 3,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -414,7 +414,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 17,
+                                            "Value": 14,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -427,8 +427,8 @@
                                     },
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 6,
-                                    "NameID": "{EX 6}",
+                                    "ID": 7,
+                                    "NameID": "{EX 7}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -457,9 +457,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 7,
-                              "NameID": "{7}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{7}",
+                              "ActionFieldID": 8,
+                              "NameID": "{8}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{8}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
@@ -494,7 +494,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 5,
+                                            "Value": 13,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -518,7 +518,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 5,
+                                            "Value": 6,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -542,7 +542,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 15,
+                                            "Value": 8,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -555,8 +555,8 @@
                                     },
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 8,
-                                    "NameID": "{EX 8}",
+                                    "ID": 9,
+                                    "NameID": "{EX 9}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -630,7 +630,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 5,
+                              "Value": 1,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -654,7 +654,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 7,
+                              "Value": 10,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -695,9 +695,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 9,
-                              "NameID": "{9}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{9}",
+                              "ActionFieldID": 10,
+                              "NameID": "{10}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{10}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
@@ -732,7 +732,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 12,
+                                            "Value": 10,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -756,7 +756,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 18,
+                                            "Value": 3,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -780,7 +780,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 2,
+                                            "Value": 12,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -793,8 +793,8 @@
                                     },
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 10,
-                                    "NameID": "{EX 10}",
+                                    "ID": 11,
+                                    "NameID": "{EX 11}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -823,9 +823,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 11,
-                              "NameID": "{11}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{11}",
+                              "ActionFieldID": 12,
+                              "NameID": "{12}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{12}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
@@ -860,7 +860,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 0,
+                                            "Value": 12,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -905,7 +905,7 @@
                                                   "min": 0,
                                                   "max": 20,
                                                   "constant": 0,
-                                                  "Value": 15,
+                                                  "Value": 2,
                                                   "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                                 },
                                                 "subexpressions": null,
@@ -929,7 +929,7 @@
                                                   "min": 0,
                                                   "max": 20,
                                                   "constant": 0,
-                                                  "Value": 0,
+                                                  "Value": 9,
                                                   "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                                 },
                                                 "subexpressions": null,
@@ -949,8 +949,8 @@
                                     },
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 12,
-                                    "NameID": "{EX 12}",
+                                    "ID": 13,
+                                    "NameID": "{EX 13}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -979,9 +979,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 13,
-                              "NameID": "{13}:ChangeControlOfCityAction:cityGainer",
-                              "ActionFieldIDString": "{13}",
+                              "ActionFieldID": 14,
+                              "NameID": "{14}:ChangeControlOfCityAction:cityGainer",
+                              "ActionFieldIDString": "{14}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "cityLoser": {
@@ -999,9 +999,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 14,
-                              "NameID": "{14}:ChangeControlOfCityAction:cityLoser",
-                              "ActionFieldIDString": "{14}",
+                              "ActionFieldID": 15,
+                              "NameID": "{15}:ChangeControlOfCityAction:cityLoser",
+                              "ActionFieldIDString": "{15}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "city": {
@@ -1019,9 +1019,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 15,
-                              "NameID": "{15}:ChangeControlOfCityAction:city",
-                              "ActionFieldIDString": "{15}",
+                              "ActionFieldID": 16,
+                              "NameID": "{16}:ChangeControlOfCityAction:city",
+                              "ActionFieldIDString": "{16}",
                               "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             }
                           }
@@ -1092,7 +1092,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 10,
+                              "Value": 15,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -1116,7 +1116,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 18,
+                              "Value": 2,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -1141,13 +1141,197 @@
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
                             "$id": "103",
-                            "$type": "Game.Incidents.TradeItemsAction, Assembly-CSharp",
-                            "givingInventory": {
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
                               "$id": "104",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 17,
+                              "NameID": "{17}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{17}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "105",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "Wealth",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "106",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "Wealth",
+                                    "Operation": "-",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "107",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "Wealth",
+                                          "range": {
+                                            "$id": "108",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 3,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "109",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "NumCities",
+                                          "range": {
+                                            "$id": "110",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 11,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 18,
+                                    "NameID": "{EX 18}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "111",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "112",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "113",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 19,
+                              "NameID": "{19}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{19}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "114",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "Wealth",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "115",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "Wealth",
+                                    "Operation": "+",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "116",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 5,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "117",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 11,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": "{EX 19}",
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 20,
+                                    "NameID": "{EX 20}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "118",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "119",
+                            "$type": "Game.Incidents.TradeAllItemsAction, Assembly-CSharp",
+                            "givingInventory": {
+                              "$id": "120",
                               "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
                               "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "actionField": {
-                                "$id": "105",
+                                "$id": "121",
                                 "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                                 "parentType": null,
                                 "AllowSelf": false,
@@ -1161,18 +1345,18 @@
                                 "value": null,
                                 "delayedValue": null,
                                 "Method": 1,
-                                "ActionFieldID": 16,
-                                "NameID": "{16}:TradeItemsAction:givingInventory",
-                                "ActionFieldIDString": "{16}",
+                                "ActionFieldID": 21,
+                                "NameID": "{21}:TradeAllItemsAction:givingInventory",
+                                "ActionFieldIDString": "{21}",
                                 "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                               }
                             },
                             "receivingInventory": {
-                              "$id": "106",
+                              "$id": "122",
                               "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
                               "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "actionField": {
-                                "$id": "107",
+                                "$id": "123",
                                 "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                                 "parentType": null,
                                 "AllowSelf": false,
@@ -1181,18 +1365,18 @@
                                   "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
                                   "$values": [
                                     {
-                                      "$id": "108",
+                                      "$id": "124",
                                       "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                                       "propertyName": "AffiliatedFaction",
                                       "evaluator": {
-                                        "$id": "109",
+                                        "$id": "125",
                                         "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
                                         "compareTo": {
-                                          "$id": "110",
+                                          "$id": "126",
                                           "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
                                           "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                           "actionField": {
-                                            "$id": "111",
+                                            "$id": "127",
                                             "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                             "parentType": null,
                                             "AllowSelf": false,
@@ -1227,195 +1411,11 @@
                                 "value": null,
                                 "delayedValue": null,
                                 "Method": 0,
-                                "ActionFieldID": 17,
-                                "NameID": "{17}:TradeItemsAction:receivingInventory",
-                                "ActionFieldIDString": "{17}",
+                                "ActionFieldID": 22,
+                                "NameID": "{22}:TradeAllItemsAction:receivingInventory",
+                                "ActionFieldIDString": "{22}",
                                 "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                               }
-                            }
-                          }
-                        },
-                        {
-                          "$id": "112",
-                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
-                          "incidentAction": {
-                            "$id": "113",
-                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
-                            "contextToModify": {
-                              "$id": "114",
-                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
-                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                              "AllowSelf": false,
-                              "AllowNull": false,
-                              "criteria": {
-                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
-                                "$values": []
-                              },
-                              "previousField": "{2}:FactionBattleContext:defender",
-                              "previousFieldID": 2,
-                              "value": null,
-                              "delayedValue": null,
-                              "Method": 1,
-                              "ActionFieldID": 18,
-                              "NameID": "{18}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{18}",
-                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                            },
-                            "modifiers": {
-                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
-                              "$values": [
-                                {
-                                  "$id": "115",
-                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
-                                  "propertyName": "Wealth",
-                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                                  "Calculator": {
-                                    "$id": "116",
-                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
-                                    "propertyName": "Wealth",
-                                    "Operation": "-",
-                                    "expressions": {
-                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
-                                      "$values": [
-                                        {
-                                          "$id": "117",
-                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
-                                          "hasNextOperator": true,
-                                          "ExpressionType": 2,
-                                          "constValue": 0,
-                                          "chosenMethod": null,
-                                          "chosenProperty": "Wealth",
-                                          "range": {
-                                            "$id": "118",
-                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-                                            "randomRange": true,
-                                            "min": 0,
-                                            "max": 20,
-                                            "constant": 0,
-                                            "Value": 15,
-                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-                                          },
-                                          "subexpressions": null,
-                                          "previousCalculatedID": null,
-                                          "rangeWarning": "Range not implemented for non integers!",
-                                          "nextOperator": "/",
-                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                                        },
-                                        {
-                                          "$id": "119",
-                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
-                                          "hasNextOperator": false,
-                                          "ExpressionType": 2,
-                                          "constValue": 0,
-                                          "chosenMethod": null,
-                                          "chosenProperty": "NumCities",
-                                          "range": {
-                                            "$id": "120",
-                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-                                            "randomRange": true,
-                                            "min": 0,
-                                            "max": 20,
-                                            "constant": 0,
-                                            "Value": 0,
-                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-                                          },
-                                          "subexpressions": null,
-                                          "previousCalculatedID": null,
-                                          "rangeWarning": "Range not implemented for non integers!",
-                                          "nextOperator": null,
-                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                                        }
-                                      ]
-                                    },
-                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 19,
-                                    "NameID": "{EX 19}",
-                                    "AllowMultipleExpressions": true
-                                  }
-                                }
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "$id": "121",
-                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
-                          "incidentAction": {
-                            "$id": "122",
-                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
-                            "contextToModify": {
-                              "$id": "123",
-                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
-                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                              "AllowSelf": false,
-                              "AllowNull": false,
-                              "criteria": {
-                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
-                                "$values": []
-                              },
-                              "previousField": "{1}:FactionBattleContext:attacker",
-                              "previousFieldID": 1,
-                              "value": null,
-                              "delayedValue": null,
-                              "Method": 1,
-                              "ActionFieldID": 20,
-                              "NameID": "{20}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{20}",
-                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                            },
-                            "modifiers": {
-                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
-                              "$values": [
-                                {
-                                  "$id": "124",
-                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
-                                  "propertyName": "Wealth",
-                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                                  "Calculator": {
-                                    "$id": "125",
-                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
-                                    "propertyName": "Wealth",
-                                    "Operation": "+",
-                                    "expressions": {
-                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
-                                      "$values": [
-                                        {
-                                          "$id": "126",
-                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
-                                          "hasNextOperator": false,
-                                          "ExpressionType": 5,
-                                          "constValue": 0,
-                                          "chosenMethod": null,
-                                          "chosenProperty": null,
-                                          "range": {
-                                            "$id": "127",
-                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-                                            "randomRange": true,
-                                            "min": 0,
-                                            "max": 20,
-                                            "constant": 0,
-                                            "Value": 0,
-                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-                                          },
-                                          "subexpressions": null,
-                                          "previousCalculatedID": "{EX 19}",
-                                          "rangeWarning": "Range not implemented for non integers!",
-                                          "nextOperator": null,
-                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                                        }
-                                      ]
-                                    },
-                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
-                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 21,
-                                    "NameID": "{EX 21}",
-                                    "AllowMultipleExpressions": true
-                                  }
-                                }
-                              ]
                             }
                           }
                         }
@@ -1485,7 +1485,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 11,
+                              "Value": 1,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -1509,7 +1509,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 14,
+                              "Value": 18,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -1550,9 +1550,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 22,
-                              "NameID": "{22}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{22}",
+                              "ActionFieldID": 23,
+                              "NameID": "{23}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{23}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
@@ -1587,7 +1587,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 7,
+                                            "Value": 2,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1611,7 +1611,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 11,
+                                            "Value": 14,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1624,8 +1624,8 @@
                                     },
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 23,
-                                    "NameID": "{EX 23}",
+                                    "ID": 24,
+                                    "NameID": "{EX 24}",
                                     "AllowMultipleExpressions": true
                                   }
                                 },
@@ -1658,7 +1658,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 10,
+                                            "Value": 16,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1682,7 +1682,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 4,
+                                            "Value": 12,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1695,8 +1695,8 @@
                                     },
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 24,
-                                    "NameID": "{EX 24}",
+                                    "ID": 25,
+                                    "NameID": "{EX 25}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -1725,9 +1725,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 25,
-                              "NameID": "{25}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{25}",
+                              "ActionFieldID": 26,
+                              "NameID": "{26}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{26}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
@@ -1775,8 +1775,8 @@
                                     },
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 26,
-                                    "NameID": "{EX 26}",
+                                    "ID": 27,
+                                    "NameID": "{EX 27}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -1805,9 +1805,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 27,
-                              "NameID": "{27}:DestroyCityAction:city",
-                              "ActionFieldIDString": "{27}",
+                              "ActionFieldID": 28,
+                              "NameID": "{28}:DestroyCityAction:city",
+                              "ActionFieldIDString": "{28}",
                               "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             }
                           }

--- a/Assets/Resources/IncidentData/Test_Battle_CitySiege.json
+++ b/Assets/Resources/IncidentData/Test_Battle_CitySiege.json
@@ -1,0 +1,1495 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "IncidentName": "Test_Battle_CitySiege",
+  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weights": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 8,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "ActionContainer": {
+    "$id": "4",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "{1} begins a siege of {2}'s city {4}.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "5",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "6",
+            "$type": "Game.Incidents.GetOrCreateCityAction, Assembly-CSharp",
+            "faction": {
+              "$id": "7",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "value": null,
+              "delayedValue": null,
+              "Method": 0,
+              "ActionFieldID": 3,
+              "NameID": "{3}:GetOrCreateCityAction:faction",
+              "ActionFieldIDString": "{3}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "location": null,
+            "population": {
+              "$id": "8",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 2,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "9",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 9,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": true,
+            "allowCreate": false,
+            "actionField": {
+              "$id": "10",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": [
+                  {
+                    "$id": "11",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "AffiliatedFaction",
+                    "evaluator": {
+                      "$id": "12",
+                      "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
+                      "compareTo": {
+                        "$id": "13",
+                        "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                        "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                        "actionField": {
+                          "$id": "14",
+                          "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                          "parentType": null,
+                          "AllowSelf": false,
+                          "AllowNull": false,
+                          "criteria": {
+                            "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                            "$values": []
+                          },
+                          "previousField": "{2}:FactionBattleContext:defender",
+                          "previousFieldID": 2,
+                          "value": null,
+                          "delayedValue": null,
+                          "Method": 1,
+                          "ActionFieldID": 0,
+                          "NameID": null,
+                          "ActionFieldIDString": "None",
+                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                        },
+                        "onSetContextType": null
+                      },
+                      "propertyName": "AffiliatedFaction",
+                      "Comparator": "==",
+                      "Type": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  {
+                    "$id": "15",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "IsOnBorder",
+                    "evaluator": {
+                      "$id": "16",
+                      "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
+                      "propertyName": "IsOnBorder",
+                      "Comparator": "==",
+                      "expressions": {
+                        "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
+                        "$values": [
+                          {
+                            "$id": "17",
+                            "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": false,
+                            "ExpressionType": 0,
+                            "constValue": true,
+                            "chosenMethod": null,
+                            "chosenProperty": null,
+                            "range": {
+                              "$id": "18",
+                              "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
+                              "Value": false,
+                              "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": null,
+                            "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          }
+                        ]
+                      },
+                      "Type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                      "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "AllowMultipleExpressions": true
+                    },
+                    "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  }
+                ]
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "value": null,
+              "delayedValue": null,
+              "Method": 0,
+              "ActionFieldID": 4,
+              "NameID": "{4}:GetOrCreateCityAction:actionField",
+              "ActionFieldIDString": "{4}",
+              "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "19",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "20",
+            "$type": "Game.Incidents.BranchingAction, Assembly-CSharp",
+            "branches": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionBranch, Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "21",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "22",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 5,
+                    "container": null,
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "23",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "{2} successfully defends {4}, repelling {1}'s invading force.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "24",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "25",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "26",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 5,
+                              "NameID": "{5}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{5}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "27",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "28",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "29",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 2,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "30",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 18,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "*",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "31",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 0,
+                                          "constValue": 4,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "32",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 5,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "33",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 0,
+                                          "constValue": 5,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "34",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 8,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 6,
+                                    "NameID": "{EX 6}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "35",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "36",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "37",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 7,
+                              "NameID": "{7}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{7}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "38",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "39",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "40",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "41",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 12,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "*",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "42",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 0,
+                                          "constValue": 9,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "43",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 13,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "44",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 0,
+                                          "constValue": 10,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "45",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 13,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 8,
+                                    "NameID": "{EX 8}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "46",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "47",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 1,
+                    "container": null,
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "48",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "{1} captures {4}.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "49",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "50",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "51",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 9,
+                              "NameID": "{9}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{9}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "52",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "53",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "54",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "55",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 12,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "*",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "56",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 0,
+                                          "constValue": 8,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "57",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 0,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "58",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 0,
+                                          "constValue": 10,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "59",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 14,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 10,
+                                    "NameID": "{EX 10}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "60",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "61",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "62",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 11,
+                              "NameID": "{11}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{11}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "63",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "64",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "-",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "65",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "66",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 14,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "67",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 4,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "NumCities",
+                                          "range": {
+                                            "$id": "68",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 15,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": {
+                                            "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                            "$values": [
+                                              {
+                                                "$id": "69",
+                                                "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                                "hasNextOperator": true,
+                                                "ExpressionType": 2,
+                                                "constValue": 0,
+                                                "chosenMethod": null,
+                                                "chosenProperty": "NumCities",
+                                                "range": {
+                                                  "$id": "70",
+                                                  "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                                  "randomRange": true,
+                                                  "min": 0,
+                                                  "max": 20,
+                                                  "constant": 0,
+                                                  "Value": 3,
+                                                  "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                                },
+                                                "subexpressions": null,
+                                                "previousCalculatedID": null,
+                                                "rangeWarning": "Range not implemented for non integers!",
+                                                "nextOperator": "+",
+                                                "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                              },
+                                              {
+                                                "$id": "71",
+                                                "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                                "hasNextOperator": false,
+                                                "ExpressionType": 0,
+                                                "constValue": 1,
+                                                "chosenMethod": null,
+                                                "chosenProperty": null,
+                                                "range": {
+                                                  "$id": "72",
+                                                  "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                                  "randomRange": true,
+                                                  "min": 0,
+                                                  "max": 20,
+                                                  "constant": 0,
+                                                  "Value": 8,
+                                                  "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                                },
+                                                "subexpressions": null,
+                                                "previousCalculatedID": null,
+                                                "rangeWarning": "Range not implemented for non integers!",
+                                                "nextOperator": null,
+                                                "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                              }
+                                            ]
+                                          },
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 12,
+                                    "NameID": "{EX 12}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "73",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "74",
+                            "$type": "Game.Incidents.ChangeControlOfCityAction, Assembly-CSharp",
+                            "cityGainer": {
+                              "$id": "75",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 13,
+                              "NameID": "{13}:ChangeControlOfCityAction:cityGainer",
+                              "ActionFieldIDString": "{13}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "cityLoser": {
+                              "$id": "76",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 14,
+                              "NameID": "{14}:ChangeControlOfCityAction:cityLoser",
+                              "ActionFieldIDString": "{14}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "city": {
+                              "$id": "77",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{4}:GetOrCreateCityAction:actionField",
+                              "previousFieldID": 4,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 15,
+                              "NameID": "{15}:ChangeControlOfCityAction:city",
+                              "ActionFieldIDString": "{15}",
+                              "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "78",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "79",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 2,
+                    "container": null,
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "80",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "{1} raiders loot and pillage {4}.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "81",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "82",
+                            "$type": "Game.Incidents.TradeItemsAction, Assembly-CSharp",
+                            "givingInventory": {
+                              "$id": "83",
+                              "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                              "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "actionField": {
+                                "$id": "84",
+                                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+                                "parentType": null,
+                                "AllowSelf": false,
+                                "AllowNull": false,
+                                "criteria": {
+                                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                  "$values": []
+                                },
+                                "previousField": "{4}:GetOrCreateCityAction:actionField",
+                                "previousFieldID": 4,
+                                "value": null,
+                                "delayedValue": null,
+                                "Method": 1,
+                                "ActionFieldID": 16,
+                                "NameID": "{16}:TradeItemsAction:givingInventory",
+                                "ActionFieldIDString": "{16}",
+                                "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                              },
+                              "onSetContextType": null
+                            },
+                            "receivingInventory": {
+                              "$id": "85",
+                              "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                              "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "actionField": {
+                                "$id": "86",
+                                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+                                "parentType": null,
+                                "AllowSelf": false,
+                                "AllowNull": false,
+                                "criteria": {
+                                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                  "$values": [
+                                    {
+                                      "$id": "87",
+                                      "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                                      "propertyName": "AffiliatedFaction",
+                                      "evaluator": {
+                                        "$id": "88",
+                                        "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
+                                        "compareTo": {
+                                          "$id": "89",
+                                          "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                                          "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                          "actionField": {
+                                            "$id": "90",
+                                            "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                            "parentType": null,
+                                            "AllowSelf": false,
+                                            "AllowNull": false,
+                                            "criteria": {
+                                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                              "$values": []
+                                            },
+                                            "previousField": "{1}:FactionBattleContext:attacker",
+                                            "previousFieldID": 1,
+                                            "value": null,
+                                            "delayedValue": null,
+                                            "Method": 1,
+                                            "ActionFieldID": 0,
+                                            "NameID": null,
+                                            "ActionFieldIDString": "None",
+                                            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                          },
+                                          "onSetContextType": null
+                                        },
+                                        "propertyName": "AffiliatedFaction",
+                                        "Comparator": "==",
+                                        "Type": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                        "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                      },
+                                      "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                      "PrimitiveType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                    }
+                                  ]
+                                },
+                                "previousField": null,
+                                "previousFieldID": -1,
+                                "value": null,
+                                "delayedValue": null,
+                                "Method": 0,
+                                "ActionFieldID": 17,
+                                "NameID": "{17}:TradeItemsAction:receivingInventory",
+                                "ActionFieldIDString": "{17}",
+                                "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                              },
+                              "onSetContextType": null
+                            }
+                          }
+                        },
+                        {
+                          "$id": "91",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "92",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "93",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 18,
+                              "NameID": "{18}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{18}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "94",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "Wealth",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "95",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "Wealth",
+                                    "Operation": "-",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "96",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "Wealth",
+                                          "range": {
+                                            "$id": "97",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 3,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "98",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "NumCities",
+                                          "range": {
+                                            "$id": "99",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 2,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 19,
+                                    "NameID": "{EX 19}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "100",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "101",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "102",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 20,
+                              "NameID": "{20}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{20}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "103",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "Wealth",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "104",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "Wealth",
+                                    "Operation": "+",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "105",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 5,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "106",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 9,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": "{EX 19}",
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 21,
+                                    "NameID": "{EX 21}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "107",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "108",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 1,
+                    "container": null,
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "109",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": null,
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "110",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "111",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "112",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 22,
+                              "NameID": "{22}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{22}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "113",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "Wealth",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "114",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "Wealth",
+                                    "Operation": "-",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "115",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "Wealth",
+                                          "range": {
+                                            "$id": "116",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 17,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "117",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "NumCities",
+                                          "range": {
+                                            "$id": "118",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 11,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 23,
+                                    "NameID": "{EX 23}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                },
+                                {
+                                  "$id": "119",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "120",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "-",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "121",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "122",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 1,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "123",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "NumCities",
+                                          "range": {
+                                            "$id": "124",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 5,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 24,
+                                    "NameID": "{EX 24}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "125",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "126",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "127",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 25,
+                              "NameID": "{25}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{25}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "128",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "129",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "-",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "130",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 5,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "131",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 11,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": "{EX 24}",
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 26,
+                                    "NameID": "{EX 26}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "132",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "133",
+                            "$type": "Game.Incidents.DestroyCityAction, Assembly-CSharp",
+                            "city": {
+                              "$id": "134",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{4}:GetOrCreateCityAction:actionField",
+                              "previousFieldID": 4,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 27,
+                              "NameID": "{27}:DestroyCityAction:city",
+                              "ActionFieldIDString": "{27}",
+                              "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Battle_CitySiege.json
+++ b/Assets/Resources/IncidentData/Test_Battle_CitySiege.json
@@ -54,31 +54,73 @@
               "ActionFieldIDString": "{3}",
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
-            "location": null,
-            "population": {
+            "location": {
               "$id": "8",
+              "$type": "Game.Incidents.LocationActionField, Assembly-CSharp",
+              "relatedFaction": {
+                "$id": "9",
+                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                "parentType": null,
+                "AllowSelf": false,
+                "AllowNull": false,
+                "criteria": {
+                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                  "$values": []
+                },
+                "previousField": null,
+                "previousFieldID": -1,
+                "value": null,
+                "delayedValue": null,
+                "Method": 0,
+                "ActionFieldID": 0,
+                "NameID": null,
+                "ActionFieldIDString": "None",
+                "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+              },
+              "minDistanceFromCities": 0,
+              "parentType": null,
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "value": null,
+              "delayedValue": null,
+              "LocationFindMethod": 0,
+              "FactionCellLocationMethod": 0,
+              "Method": 0,
+              "ActionFieldID": 0,
+              "NameID": null,
+              "ActionFieldIDString": "None",
+              "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "population": {
+              "$id": "10",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 15,
+              "Value": 13,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "wealth": {
-              "$id": "9",
+              "$id": "11",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 1,
+              "Value": 5,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "findFirst": true,
-            "allowCreate": false,
+            "allowCreate": true,
             "actionField": {
-              "$id": "10",
+              "$id": "12",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -87,18 +129,18 @@
                 "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
                 "$values": [
                   {
-                    "$id": "11",
+                    "$id": "13",
                     "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                     "propertyName": "AffiliatedFaction",
                     "evaluator": {
-                      "$id": "12",
+                      "$id": "14",
                       "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
                       "compareTo": {
-                        "$id": "13",
+                        "$id": "15",
                         "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
                         "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                         "actionField": {
-                          "$id": "14",
+                          "$id": "16",
                           "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                           "parentType": null,
                           "AllowSelf": false,
@@ -127,11 +169,11 @@
                     "PrimitiveType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                   },
                   {
-                    "$id": "15",
+                    "$id": "17",
                     "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                     "propertyName": "IsOnBorder",
                     "evaluator": {
-                      "$id": "16",
+                      "$id": "18",
                       "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
                       "propertyName": "IsOnBorder",
                       "Comparator": "==",
@@ -139,7 +181,7 @@
                         "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
                         "$values": [
                           {
-                            "$id": "17",
+                            "$id": "19",
                             "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
                             "hasNextOperator": false,
                             "ExpressionType": 0,
@@ -147,7 +189,7 @@
                             "chosenMethod": null,
                             "chosenProperty": null,
                             "range": {
-                              "$id": "18",
+                              "$id": "20",
                               "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
                               "Value": false,
                               "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
@@ -182,28 +224,28 @@
           }
         },
         {
-          "$id": "19",
+          "$id": "21",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "20",
+            "$id": "22",
             "$type": "Game.Incidents.BranchingAction, Assembly-CSharp",
             "branches": {
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionBranch, Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "21",
+                  "$id": "23",
                   "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
                   "weightModifier": {
-                    "$id": "22",
+                    "$id": "24",
                     "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
                     "advancedMode": true,
                     "baseWeight": 5,
                     "container": {
-                      "$id": "23",
+                      "$id": "25",
                       "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
                       "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                       "actionField": {
-                        "$id": "24",
+                        "$id": "26",
                         "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                         "parentType": null,
                         "AllowSelf": false,
@@ -224,7 +266,7 @@
                       }
                     },
                     "weight": {
-                      "$id": "25",
+                      "$id": "27",
                       "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                       "baseWeight": 5,
                       "Operation": "+",
@@ -232,7 +274,7 @@
                         "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                         "$values": [
                           {
-                            "$id": "26",
+                            "$id": "28",
                             "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                             "hasNextOperator": false,
                             "ExpressionType": 2,
@@ -240,13 +282,13 @@
                             "chosenMethod": null,
                             "chosenProperty": "MilitaryPower",
                             "range": {
-                              "$id": "27",
+                              "$id": "29",
                               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                               "randomRange": true,
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 19,
+                              "Value": 18,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -260,20 +302,20 @@
                     }
                   },
                   "actionHandler": {
-                    "$id": "28",
+                    "$id": "30",
                     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
                     "incidentLog": "{2} successfully defends {4}, repelling {1}'s invading force.",
                     "Actions": {
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "29",
+                          "$id": "31",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "30",
+                            "$id": "32",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "31",
+                              "$id": "33",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -296,13 +338,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "32",
+                                  "$id": "34",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "33",
+                                    "$id": "35",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "=",
@@ -310,7 +352,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "34",
+                                          "$id": "36",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -318,13 +360,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "35",
+                                            "$id": "37",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 5,
+                                            "Value": 0,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -334,7 +376,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "36",
+                                          "$id": "38",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 0,
@@ -342,13 +384,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "37",
+                                            "$id": "39",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 7,
+                                            "Value": 15,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -358,7 +400,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "38",
+                                          "$id": "40",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 0,
@@ -366,7 +408,7 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "39",
+                                            "$id": "41",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
@@ -395,13 +437,13 @@
                           }
                         },
                         {
-                          "$id": "40",
+                          "$id": "42",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "41",
+                            "$id": "43",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "42",
+                              "$id": "44",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -424,13 +466,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "43",
+                                  "$id": "45",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "44",
+                                    "$id": "46",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "=",
@@ -438,7 +480,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "45",
+                                          "$id": "47",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -446,13 +488,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "46",
+                                            "$id": "48",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 16,
+                                            "Value": 5,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -462,35 +504,11 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "47",
+                                          "$id": "49",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 0,
                                           "constValue": 9,
-                                          "chosenMethod": null,
-                                          "chosenProperty": null,
-                                          "range": {
-                                            "$id": "48",
-                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-                                            "randomRange": true,
-                                            "min": 0,
-                                            "max": 20,
-                                            "constant": 0,
-                                            "Value": 1,
-                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-                                          },
-                                          "subexpressions": null,
-                                          "previousCalculatedID": null,
-                                          "rangeWarning": "Range not implemented for non integers!",
-                                          "nextOperator": "/",
-                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
-                                        },
-                                        {
-                                          "$id": "49",
-                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
-                                          "hasNextOperator": false,
-                                          "ExpressionType": 0,
-                                          "constValue": 10,
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
@@ -500,7 +518,31 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 10,
+                                            "Value": 5,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "51",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 0,
+                                          "constValue": 10,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "52",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 15,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -533,31 +575,113 @@
                   "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                 },
                 {
-                  "$id": "51",
+                  "$id": "53",
                   "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
                   "weightModifier": {
-                    "$id": "52",
+                    "$id": "54",
                     "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
-                    "advancedMode": false,
+                    "advancedMode": true,
                     "baseWeight": 1,
-                    "container": null,
-                    "weight": null
+                    "container": {
+                      "$id": "55",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "actionField": {
+                        "$id": "56",
+                        "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                        "parentType": null,
+                        "AllowSelf": false,
+                        "AllowNull": false,
+                        "criteria": {
+                          "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                          "$values": []
+                        },
+                        "previousField": "{1}:FactionBattleContext:attacker",
+                        "previousFieldID": 1,
+                        "value": null,
+                        "delayedValue": null,
+                        "Method": 1,
+                        "ActionFieldID": 0,
+                        "NameID": null,
+                        "ActionFieldIDString": "None",
+                        "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                      }
+                    },
+                    "weight": {
+                      "$id": "57",
+                      "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                      "baseWeight": 1,
+                      "Operation": "=",
+                      "expressions": {
+                        "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                        "$values": [
+                          {
+                            "$id": "58",
+                            "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": true,
+                            "ExpressionType": 2,
+                            "constValue": 0,
+                            "chosenMethod": null,
+                            "chosenProperty": "MilitaryPower",
+                            "range": {
+                              "$id": "59",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 5,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": "/",
+                            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          },
+                          {
+                            "$id": "60",
+                            "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": false,
+                            "ExpressionType": 0,
+                            "constValue": 4,
+                            "chosenMethod": null,
+                            "chosenProperty": null,
+                            "range": {
+                              "$id": "61",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 7,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": null,
+                            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          }
+                        ]
+                      }
+                    }
                   },
                   "actionHandler": {
-                    "$id": "53",
+                    "$id": "62",
                     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
                     "incidentLog": "{1} captures {4}.",
                     "Actions": {
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "54",
+                          "$id": "63",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "55",
+                            "$id": "64",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "56",
+                              "$id": "65",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -580,13 +704,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "57",
+                                  "$id": "66",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "58",
+                                    "$id": "67",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "=",
@@ -594,7 +718,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "59",
+                                          "$id": "68",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -602,13 +726,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "60",
+                                            "$id": "69",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 14,
+                                            "Value": 12,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -618,7 +742,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "61",
+                                          "$id": "70",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 0,
@@ -626,13 +750,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "62",
+                                            "$id": "71",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 2,
+                                            "Value": 18,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -642,7 +766,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "63",
+                                          "$id": "72",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 0,
@@ -650,13 +774,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "64",
+                                            "$id": "73",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 6,
+                                            "Value": 2,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -679,13 +803,13 @@
                           }
                         },
                         {
-                          "$id": "65",
+                          "$id": "74",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "66",
+                            "$id": "75",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "67",
+                              "$id": "76",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -708,13 +832,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "68",
+                                  "$id": "77",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "69",
+                                    "$id": "78",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "-",
@@ -722,7 +846,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "70",
+                                          "$id": "79",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -730,13 +854,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "71",
+                                            "$id": "80",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 1,
+                                            "Value": 0,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -746,7 +870,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "72",
+                                          "$id": "81",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 4,
@@ -754,20 +878,20 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "NumCities",
                                           "range": {
-                                            "$id": "73",
+                                            "$id": "82",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 7,
+                                            "Value": 1,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": {
                                             "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                             "$values": [
                                               {
-                                                "$id": "74",
+                                                "$id": "83",
                                                 "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                                 "hasNextOperator": true,
                                                 "ExpressionType": 2,
@@ -775,13 +899,13 @@
                                                 "chosenMethod": null,
                                                 "chosenProperty": "NumCities",
                                                 "range": {
-                                                  "$id": "75",
+                                                  "$id": "84",
                                                   "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                                   "randomRange": true,
                                                   "min": 0,
                                                   "max": 20,
                                                   "constant": 0,
-                                                  "Value": 5,
+                                                  "Value": 15,
                                                   "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                                 },
                                                 "subexpressions": null,
@@ -791,7 +915,7 @@
                                                 "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                               },
                                               {
-                                                "$id": "76",
+                                                "$id": "85",
                                                 "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                                 "hasNextOperator": false,
                                                 "ExpressionType": 0,
@@ -799,13 +923,13 @@
                                                 "chosenMethod": null,
                                                 "chosenProperty": null,
                                                 "range": {
-                                                  "$id": "77",
+                                                  "$id": "86",
                                                   "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                                   "randomRange": true,
                                                   "min": 0,
                                                   "max": 20,
                                                   "constant": 0,
-                                                  "Value": 2,
+                                                  "Value": 0,
                                                   "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                                 },
                                                 "subexpressions": null,
@@ -835,13 +959,13 @@
                           }
                         },
                         {
-                          "$id": "78",
+                          "$id": "87",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "79",
+                            "$id": "88",
                             "$type": "Game.Incidents.ChangeControlOfCityAction, Assembly-CSharp",
                             "cityGainer": {
-                              "$id": "80",
+                              "$id": "89",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -861,7 +985,7 @@
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "cityLoser": {
-                              "$id": "81",
+                              "$id": "90",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -881,7 +1005,7 @@
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "city": {
-                              "$id": "82",
+                              "$id": "91",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -913,35 +1037,117 @@
                   "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                 },
                 {
-                  "$id": "83",
+                  "$id": "92",
                   "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
                   "weightModifier": {
-                    "$id": "84",
+                    "$id": "93",
                     "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
-                    "advancedMode": false,
+                    "advancedMode": true,
                     "baseWeight": 2,
-                    "container": null,
-                    "weight": null
+                    "container": {
+                      "$id": "94",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "actionField": {
+                        "$id": "95",
+                        "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                        "parentType": null,
+                        "AllowSelf": false,
+                        "AllowNull": false,
+                        "criteria": {
+                          "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                          "$values": []
+                        },
+                        "previousField": "{1}:FactionBattleContext:attacker",
+                        "previousFieldID": 1,
+                        "value": null,
+                        "delayedValue": null,
+                        "Method": 1,
+                        "ActionFieldID": 0,
+                        "NameID": null,
+                        "ActionFieldIDString": "None",
+                        "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                      }
+                    },
+                    "weight": {
+                      "$id": "96",
+                      "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                      "baseWeight": 1,
+                      "Operation": "=",
+                      "expressions": {
+                        "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                        "$values": [
+                          {
+                            "$id": "97",
+                            "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": true,
+                            "ExpressionType": 2,
+                            "constValue": 0,
+                            "chosenMethod": null,
+                            "chosenProperty": "MilitaryPower",
+                            "range": {
+                              "$id": "98",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 10,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": "/",
+                            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          },
+                          {
+                            "$id": "99",
+                            "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": false,
+                            "ExpressionType": 0,
+                            "constValue": 3,
+                            "chosenMethod": null,
+                            "chosenProperty": null,
+                            "range": {
+                              "$id": "100",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 18,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": null,
+                            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          }
+                        ]
+                      }
+                    }
                   },
                   "actionHandler": {
-                    "$id": "85",
+                    "$id": "101",
                     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
                     "incidentLog": "{1} raiders loot and pillage {4}.",
                     "Actions": {
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "86",
+                          "$id": "102",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "87",
+                            "$id": "103",
                             "$type": "Game.Incidents.TradeItemsAction, Assembly-CSharp",
                             "givingInventory": {
-                              "$id": "88",
+                              "$id": "104",
                               "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
                               "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "actionField": {
-                                "$id": "89",
+                                "$id": "105",
                                 "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                                 "parentType": null,
                                 "AllowSelf": false,
@@ -962,11 +1168,11 @@
                               }
                             },
                             "receivingInventory": {
-                              "$id": "90",
+                              "$id": "106",
                               "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
                               "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "actionField": {
-                                "$id": "91",
+                                "$id": "107",
                                 "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                                 "parentType": null,
                                 "AllowSelf": false,
@@ -975,18 +1181,18 @@
                                   "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
                                   "$values": [
                                     {
-                                      "$id": "92",
+                                      "$id": "108",
                                       "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                                       "propertyName": "AffiliatedFaction",
                                       "evaluator": {
-                                        "$id": "93",
+                                        "$id": "109",
                                         "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
                                         "compareTo": {
-                                          "$id": "94",
+                                          "$id": "110",
                                           "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
                                           "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                           "actionField": {
-                                            "$id": "95",
+                                            "$id": "111",
                                             "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                             "parentType": null,
                                             "AllowSelf": false,
@@ -1030,13 +1236,13 @@
                           }
                         },
                         {
-                          "$id": "96",
+                          "$id": "112",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "97",
+                            "$id": "113",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "98",
+                              "$id": "114",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1059,13 +1265,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "99",
+                                  "$id": "115",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "Wealth",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "100",
+                                    "$id": "116",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "Wealth",
                                     "Operation": "-",
@@ -1073,7 +1279,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "101",
+                                          "$id": "117",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -1081,13 +1287,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "Wealth",
                                           "range": {
-                                            "$id": "102",
+                                            "$id": "118",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 17,
+                                            "Value": 15,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1097,7 +1303,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "103",
+                                          "$id": "119",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 2,
@@ -1105,13 +1311,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "NumCities",
                                           "range": {
-                                            "$id": "104",
+                                            "$id": "120",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 15,
+                                            "Value": 0,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1134,13 +1340,13 @@
                           }
                         },
                         {
-                          "$id": "105",
+                          "$id": "121",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "106",
+                            "$id": "122",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "107",
+                              "$id": "123",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1163,13 +1369,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "108",
+                                  "$id": "124",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "Wealth",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "109",
+                                    "$id": "125",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "Wealth",
                                     "Operation": "+",
@@ -1177,7 +1383,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "110",
+                                          "$id": "126",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 5,
@@ -1185,13 +1391,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "111",
+                                            "$id": "127",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 10,
+                                            "Value": 0,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1224,31 +1430,113 @@
                   "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                 },
                 {
-                  "$id": "112",
+                  "$id": "128",
                   "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
                   "weightModifier": {
-                    "$id": "113",
+                    "$id": "129",
                     "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
-                    "advancedMode": false,
+                    "advancedMode": true,
                     "baseWeight": 1,
-                    "container": null,
-                    "weight": null
+                    "container": {
+                      "$id": "130",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "actionField": {
+                        "$id": "131",
+                        "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                        "parentType": null,
+                        "AllowSelf": false,
+                        "AllowNull": false,
+                        "criteria": {
+                          "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                          "$values": []
+                        },
+                        "previousField": "{1}:FactionBattleContext:attacker",
+                        "previousFieldID": 1,
+                        "value": null,
+                        "delayedValue": null,
+                        "Method": 1,
+                        "ActionFieldID": 0,
+                        "NameID": null,
+                        "ActionFieldIDString": "None",
+                        "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                      }
+                    },
+                    "weight": {
+                      "$id": "132",
+                      "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                      "baseWeight": 1,
+                      "Operation": "=",
+                      "expressions": {
+                        "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                        "$values": [
+                          {
+                            "$id": "133",
+                            "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": true,
+                            "ExpressionType": 2,
+                            "constValue": 0,
+                            "chosenMethod": null,
+                            "chosenProperty": "MilitaryPower",
+                            "range": {
+                              "$id": "134",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 11,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": "/",
+                            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          },
+                          {
+                            "$id": "135",
+                            "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": false,
+                            "ExpressionType": 0,
+                            "constValue": 5,
+                            "chosenMethod": null,
+                            "chosenProperty": null,
+                            "range": {
+                              "$id": "136",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 14,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": null,
+                            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          }
+                        ]
+                      }
+                    }
                   },
                   "actionHandler": {
-                    "$id": "114",
+                    "$id": "137",
                     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
                     "incidentLog": null,
                     "Actions": {
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "115",
+                          "$id": "138",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "116",
+                            "$id": "139",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "117",
+                              "$id": "140",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1271,13 +1559,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "118",
+                                  "$id": "141",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "Wealth",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "119",
+                                    "$id": "142",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "Wealth",
                                     "Operation": "-",
@@ -1285,7 +1573,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "120",
+                                          "$id": "143",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -1293,13 +1581,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "Wealth",
                                           "range": {
-                                            "$id": "121",
+                                            "$id": "144",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 0,
+                                            "Value": 7,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1309,7 +1597,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "122",
+                                          "$id": "145",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 2,
@@ -1317,13 +1605,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "NumCities",
                                           "range": {
-                                            "$id": "123",
+                                            "$id": "146",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 19,
+                                            "Value": 11,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1342,13 +1630,13 @@
                                   }
                                 },
                                 {
-                                  "$id": "124",
+                                  "$id": "147",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "125",
+                                    "$id": "148",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "-",
@@ -1356,7 +1644,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "126",
+                                          "$id": "149",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": true,
                                           "ExpressionType": 2,
@@ -1364,13 +1652,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "MilitaryPower",
                                           "range": {
-                                            "$id": "127",
+                                            "$id": "150",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 15,
+                                            "Value": 10,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1380,7 +1668,7 @@
                                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                                         },
                                         {
-                                          "$id": "128",
+                                          "$id": "151",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 2,
@@ -1388,13 +1676,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": "NumCities",
                                           "range": {
-                                            "$id": "129",
+                                            "$id": "152",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 13,
+                                            "Value": 4,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1417,13 +1705,13 @@
                           }
                         },
                         {
-                          "$id": "130",
+                          "$id": "153",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "131",
+                            "$id": "154",
                             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
                             "contextToModify": {
-                              "$id": "132",
+                              "$id": "155",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,
@@ -1446,13 +1734,13 @@
                               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
                               "$values": [
                                 {
-                                  "$id": "133",
+                                  "$id": "156",
                                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                                   "propertyName": "MilitaryPower",
                                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                   "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                   "Calculator": {
-                                    "$id": "134",
+                                    "$id": "157",
                                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                                     "propertyName": "MilitaryPower",
                                     "Operation": "-",
@@ -1460,7 +1748,7 @@
                                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                                       "$values": [
                                         {
-                                          "$id": "135",
+                                          "$id": "158",
                                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                                           "hasNextOperator": false,
                                           "ExpressionType": 5,
@@ -1468,13 +1756,13 @@
                                           "chosenMethod": null,
                                           "chosenProperty": null,
                                           "range": {
-                                            "$id": "136",
+                                            "$id": "159",
                                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                                             "randomRange": true,
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 2,
+                                            "Value": 1,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -1497,13 +1785,13 @@
                           }
                         },
                         {
-                          "$id": "137",
+                          "$id": "160",
                           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
                           "incidentAction": {
-                            "$id": "138",
+                            "$id": "161",
                             "$type": "Game.Incidents.DestroyCityAction, Assembly-CSharp",
                             "city": {
-                              "$id": "139",
+                              "$id": "162",
                               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
                               "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                               "AllowSelf": false,

--- a/Assets/Resources/IncidentData/Test_Battle_HexBattle.json
+++ b/Assets/Resources/IncidentData/Test_Battle_HexBattle.json
@@ -232,7 +232,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 1,
+                                            "Value": 10,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -256,7 +256,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 18,
+                                            "Value": 0,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -267,6 +267,7 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                     "ID": 5,
@@ -336,7 +337,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 13,
+                                            "Value": 19,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -371,6 +372,7 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                                     "ID": 7,
@@ -466,9 +468,9 @@
                               "LocationFindMethod": 0,
                               "FactionCellLocationMethod": 0,
                               "Method": 1,
-                              "ActionFieldID": 0,
-                              "NameID": null,
-                              "ActionFieldIDString": "None",
+                              "ActionFieldID": 10,
+                              "NameID": "{10}:ChangeControlOfTerritoryAction:location",
+                              "ActionFieldIDString": "{10}",
                               "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             }
                           }
@@ -539,7 +541,7 @@
                               "min": 0,
                               "max": 20,
                               "constant": 0,
-                              "Value": 9,
+                              "Value": 17,
                               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                             },
                             "subexpressions": null,
@@ -580,9 +582,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 10,
-                              "NameID": "{10}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{10}",
+                              "ActionFieldID": 11,
+                              "NameID": "{11}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{11}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
@@ -641,7 +643,7 @@
                                             "min": 5,
                                             "max": 8,
                                             "constant": 0,
-                                            "Value": 5,
+                                            "Value": 6,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -652,10 +654,11 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 11,
-                                    "NameID": "{EX 11}",
+                                    "ID": 12,
+                                    "NameID": "{EX 12}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -684,9 +687,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 12,
-                              "NameID": "{12}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{12}",
+                              "ActionFieldID": 13,
+                              "NameID": "{13}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{13}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
@@ -721,7 +724,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 10,
+                                            "Value": 12,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -756,10 +759,11 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 13,
-                                    "NameID": "{EX 13}",
+                                    "ID": 14,
+                                    "NameID": "{EX 14}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -821,9 +825,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 14,
-                              "NameID": "{14}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{14}",
+                              "ActionFieldID": 15,
+                              "NameID": "{15}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{15}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
@@ -858,7 +862,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 1,
+                                            "Value": 9,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -893,10 +897,11 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 15,
-                                    "NameID": "{EX 15}",
+                                    "ID": 16,
+                                    "NameID": "{EX 16}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -925,9 +930,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 1,
-                              "ActionFieldID": 16,
-                              "NameID": "{16}:ModifyFactionAction:contextToModify",
-                              "ActionFieldIDString": "{16}",
+                              "ActionFieldID": 17,
+                              "NameID": "{17}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{17}",
                               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "modifiers": {
@@ -962,7 +967,7 @@
                                             "min": 0,
                                             "max": 20,
                                             "constant": 0,
-                                            "Value": 10,
+                                            "Value": 1,
                                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                                           },
                                           "subexpressions": null,
@@ -997,10 +1002,11 @@
                                         }
                                       ]
                                     },
+                                    "clamped": true,
                                     "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                                    "ID": 17,
-                                    "NameID": "{EX 17}",
+                                    "ID": 18,
+                                    "NameID": "{EX 18}",
                                     "AllowMultipleExpressions": true
                                   }
                                 }
@@ -1098,9 +1104,9 @@
                               "LocationFindMethod": 0,
                               "FactionCellLocationMethod": 0,
                               "Method": 1,
-                              "ActionFieldID": 0,
-                              "NameID": null,
-                              "ActionFieldIDString": "None",
+                              "ActionFieldID": 20,
+                              "NameID": "{20}:GetOrCreateLandmarkAction:location",
+                              "ActionFieldIDString": "{20}",
                               "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             },
                             "findFirst": false,
@@ -1120,9 +1126,9 @@
                               "value": null,
                               "delayedValue": null,
                               "Method": 0,
-                              "ActionFieldID": 18,
-                              "NameID": "{18}:GetOrCreateLandmarkAction:actionField",
-                              "ActionFieldIDString": "{18}",
+                              "ActionFieldID": 19,
+                              "NameID": "{19}:GetOrCreateLandmarkAction:actionField",
+                              "ActionFieldIDString": "{19}",
                               "ContextType": "Game.Incidents.Landmark, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                             }
                           }

--- a/Assets/Resources/IncidentData/Test_Battle_HexBattle.json
+++ b/Assets/Resources/IncidentData/Test_Battle_HexBattle.json
@@ -1,0 +1,1184 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "IncidentName": "Test_Battle_HexBattle",
+  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weights": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.FactionBattleContext, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 10,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "ActionContainer": {
+    "$id": "4",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "{1} and {2} fight a battle at {3}.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "5",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "6",
+            "$type": "Game.Incidents.GetContextsAction, Assembly-CSharp",
+            "actionFields": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "7",
+                  "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                  "contextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "actionField": {
+                    "$id": "8",
+                    "$type": "Game.Incidents.LocationActionField, Assembly-CSharp",
+                    "relatedFaction": {
+                      "$id": "9",
+                      "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                      "parentType": null,
+                      "AllowSelf": false,
+                      "AllowNull": false,
+                      "criteria": {
+                        "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                        "$values": []
+                      },
+                      "previousField": "{2}:FactionBattleContext:defender",
+                      "previousFieldID": 2,
+                      "value": null,
+                      "delayedValue": null,
+                      "Method": 1,
+                      "ActionFieldID": 0,
+                      "NameID": null,
+                      "ActionFieldIDString": "None",
+                      "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "minDistanceFromCities": 0,
+                    "parentType": null,
+                    "AllowSelf": false,
+                    "AllowNull": false,
+                    "criteria": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "previousField": null,
+                    "previousFieldID": -1,
+                    "value": null,
+                    "delayedValue": null,
+                    "LocationFindMethod": 2,
+                    "FactionCellLocationMethod": 1,
+                    "Method": 0,
+                    "ActionFieldID": 3,
+                    "NameID": "{3}:GetContextsAction:actionFields",
+                    "ActionFieldIDString": "{3}",
+                    "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$id": "10",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "11",
+            "$type": "Game.Incidents.BranchingAction, Assembly-CSharp",
+            "branches": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionBranch, Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "12",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "13",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": true,
+                    "baseWeight": 0,
+                    "container": {
+                      "$id": "14",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "actionField": {
+                        "$id": "15",
+                        "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                        "parentType": null,
+                        "AllowSelf": false,
+                        "AllowNull": false,
+                        "criteria": {
+                          "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                          "$values": []
+                        },
+                        "previousField": "{1}:FactionBattleContext:attacker",
+                        "previousFieldID": 1,
+                        "value": null,
+                        "delayedValue": null,
+                        "Method": 1,
+                        "ActionFieldID": 0,
+                        "NameID": null,
+                        "ActionFieldIDString": "None",
+                        "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                      }
+                    },
+                    "weight": {
+                      "$id": "16",
+                      "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                      "baseWeight": 0,
+                      "Operation": "+",
+                      "expressions": {
+                        "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                        "$values": [
+                          {
+                            "$id": "17",
+                            "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": false,
+                            "ExpressionType": 2,
+                            "constValue": 0,
+                            "chosenMethod": null,
+                            "chosenProperty": "MilitaryPower",
+                            "range": {
+                              "$id": "18",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 15,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": null,
+                            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "actionHandler": {
+                    "$id": "19",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "{2} is defeated.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "20",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "21",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "22",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 4,
+                              "NameID": "{4}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{4}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "23",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "24",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "25",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "26",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 1,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "27",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 0,
+                                          "constValue": 10,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "28",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 18,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 5,
+                                    "NameID": "{EX 5}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "29",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "30",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "31",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 6,
+                              "NameID": "{6}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{6}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "32",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "33",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "34",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "35",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 13,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "36",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "37",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 5,
+                                            "max": 10,
+                                            "constant": 0,
+                                            "Value": 7,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 7,
+                                    "NameID": "{EX 7}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "38",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "39",
+                            "$type": "Game.Incidents.ChangeControlOfTerritoryAction, Assembly-CSharp",
+                            "territoryGainer": {
+                              "$id": "40",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 8,
+                              "NameID": "{8}:ChangeControlOfTerritoryAction:territoryGainer",
+                              "ActionFieldIDString": "{8}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "territoryLoser": {
+                              "$id": "41",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 9,
+                              "NameID": "{9}:ChangeControlOfTerritoryAction:territoryLoser",
+                              "ActionFieldIDString": "{9}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "location": {
+                              "$id": "42",
+                              "$type": "Game.Incidents.LocationActionField, Assembly-CSharp",
+                              "relatedFaction": {
+                                "$id": "43",
+                                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                "parentType": null,
+                                "AllowSelf": false,
+                                "AllowNull": false,
+                                "criteria": {
+                                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                  "$values": []
+                                },
+                                "previousField": null,
+                                "previousFieldID": -1,
+                                "value": null,
+                                "delayedValue": null,
+                                "Method": 0,
+                                "ActionFieldID": 0,
+                                "NameID": null,
+                                "ActionFieldIDString": "None",
+                                "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                              },
+                              "minDistanceFromCities": 0,
+                              "parentType": null,
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{3}:GetContextsAction:actionFields",
+                              "previousFieldID": 3,
+                              "value": null,
+                              "delayedValue": null,
+                              "LocationFindMethod": 0,
+                              "FactionCellLocationMethod": 0,
+                              "Method": 1,
+                              "ActionFieldID": 0,
+                              "NameID": null,
+                              "ActionFieldIDString": "None",
+                              "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "44",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "45",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": true,
+                    "baseWeight": 0,
+                    "container": {
+                      "$id": "46",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "actionField": {
+                        "$id": "47",
+                        "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                        "parentType": null,
+                        "AllowSelf": false,
+                        "AllowNull": false,
+                        "criteria": {
+                          "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                          "$values": []
+                        },
+                        "previousField": "{2}:FactionBattleContext:defender",
+                        "previousFieldID": 2,
+                        "value": null,
+                        "delayedValue": null,
+                        "Method": 1,
+                        "ActionFieldID": 0,
+                        "NameID": null,
+                        "ActionFieldIDString": "None",
+                        "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                      }
+                    },
+                    "weight": {
+                      "$id": "48",
+                      "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                      "baseWeight": 0,
+                      "Operation": "+",
+                      "expressions": {
+                        "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                        "$values": [
+                          {
+                            "$id": "49",
+                            "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": false,
+                            "ExpressionType": 2,
+                            "constValue": 0,
+                            "chosenMethod": null,
+                            "chosenProperty": "MilitaryPower",
+                            "range": {
+                              "$id": "50",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 9,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": null,
+                            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "actionHandler": {
+                    "$id": "51",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "{2} stands firm and {1} is forced to retreat.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "52",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "53",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "54",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 10,
+                              "NameID": "{10}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{10}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "55",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "56",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "57",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "58",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 16,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "59",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "60",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 5,
+                                            "max": 8,
+                                            "constant": 0,
+                                            "Value": 5,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 11,
+                                    "NameID": "{EX 11}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "61",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "62",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "63",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 12,
+                              "NameID": "{12}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{12}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "64",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "65",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "66",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "67",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 10,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "68",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "69",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 8,
+                                            "max": 10,
+                                            "constant": 0,
+                                            "Value": 8,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 13,
+                                    "NameID": "{EX 13}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "70",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "71",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 20,
+                    "container": {
+                      "$id": "72",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": null,
+                      "actionField": null
+                    },
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "73",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "{1} and {2} are each forced to retreat. There is no clear victor.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "74",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "75",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "76",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 14,
+                              "NameID": "{14}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{14}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "77",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPriority",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "78",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPriority",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "79",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "80",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 1,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "81",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "82",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 7,
+                                            "max": 10,
+                                            "constant": 0,
+                                            "Value": 9,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 15,
+                                    "NameID": "{EX 15}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "83",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "84",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "85",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 16,
+                              "NameID": "{16}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{16}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "86",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "87",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "88",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "89",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 10,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "90",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "91",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 7,
+                                            "max": 10,
+                                            "constant": 0,
+                                            "Value": 8,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 17,
+                                    "NameID": "{EX 17}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$id": "92",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "93",
+            "$type": "Game.Incidents.BranchingAction, Assembly-CSharp",
+            "branches": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionBranch, Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "94",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "95",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 1,
+                    "container": {
+                      "$id": "96",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": null,
+                      "actionField": null
+                    },
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "97",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "{18} is left behind marking the place of battle.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "98",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "99",
+                            "$type": "Game.Incidents.GetOrCreateLandmarkAction, Assembly-CSharp",
+                            "location": {
+                              "$id": "100",
+                              "$type": "Game.Incidents.LocationActionField, Assembly-CSharp",
+                              "relatedFaction": {
+                                "$id": "101",
+                                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                "parentType": null,
+                                "AllowSelf": false,
+                                "AllowNull": false,
+                                "criteria": {
+                                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                  "$values": []
+                                },
+                                "previousField": null,
+                                "previousFieldID": -1,
+                                "value": null,
+                                "delayedValue": null,
+                                "Method": 0,
+                                "ActionFieldID": 0,
+                                "NameID": null,
+                                "ActionFieldIDString": "None",
+                                "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                              },
+                              "minDistanceFromCities": 0,
+                              "parentType": null,
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{3}:GetContextsAction:actionFields",
+                              "previousFieldID": 3,
+                              "value": null,
+                              "delayedValue": null,
+                              "LocationFindMethod": 0,
+                              "FactionCellLocationMethod": 0,
+                              "Method": 1,
+                              "ActionFieldID": 0,
+                              "NameID": null,
+                              "ActionFieldIDString": "None",
+                              "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "findFirst": false,
+                            "allowCreate": true,
+                            "actionField": {
+                              "$id": "102",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Landmark, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": null,
+                              "previousFieldID": -1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 0,
+                              "ActionFieldID": 18,
+                              "NameID": "{18}:GetOrCreateLandmarkAction:actionField",
+                              "ActionFieldIDString": "{18}",
+                              "ContextType": "Game.Incidents.Landmark, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "103",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "104",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 7,
+                    "container": {
+                      "$id": "105",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": null,
+                      "actionField": null
+                    },
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "106",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": null,
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Battle_HexBattle.json.meta
+++ b/Assets/Resources/IncidentData/Test_Battle_HexBattle.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f3fdc6c3d0e665c4ba241371c1fd525a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Battle_RelicWar.json
+++ b/Assets/Resources/IncidentData/Test_Battle_RelicWar.json
@@ -1,0 +1,1416 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "IncidentName": "Test_Battle_RelicWar",
+  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weights": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.FactionBattleContext, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 3,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "ActionContainer": {
+    "$id": "4",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": null,
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "5",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "6",
+            "$type": "Game.Incidents.GetOrCreateCityAction, Assembly-CSharp",
+            "faction": {
+              "$id": "7",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "value": null,
+              "delayedValue": null,
+              "Method": 0,
+              "ActionFieldID": 3,
+              "NameID": "{3}:GetOrCreateCityAction:faction",
+              "ActionFieldIDString": "{3}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "location": {
+              "$id": "8",
+              "$type": "Game.Incidents.LocationActionField, Assembly-CSharp",
+              "relatedFaction": null,
+              "minDistanceFromCities": 0,
+              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "value": null,
+              "delayedValue": null,
+              "LocationFindMethod": 0,
+              "FactionCellLocationMethod": 0,
+              "Method": 0,
+              "ActionFieldID": 5,
+              "NameID": "{5}:GetOrCreateCityAction:location",
+              "ActionFieldIDString": "{5}",
+              "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "population": {
+              "$id": "9",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 15,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "10",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 10,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": true,
+            "allowCreate": false,
+            "actionField": {
+              "$id": "11",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": [
+                  {
+                    "$id": "12",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "NumItems",
+                    "evaluator": {
+                      "$id": "13",
+                      "$type": "Game.Incidents.IntegerEvaluator, Assembly-CSharp",
+                      "propertyName": "NumItems",
+                      "Comparator": ">",
+                      "expressions": {
+                        "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                        "$values": [
+                          {
+                            "$id": "14",
+                            "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                            "hasNextOperator": false,
+                            "ExpressionType": 0,
+                            "constValue": 0,
+                            "chosenMethod": null,
+                            "chosenProperty": null,
+                            "range": {
+                              "$id": "15",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 0,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "subexpressions": null,
+                            "previousCalculatedID": null,
+                            "rangeWarning": "Range not implemented for non integers!",
+                            "nextOperator": null,
+                            "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          }
+                        ]
+                      },
+                      "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                      "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "AllowMultipleExpressions": true
+                    },
+                    "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  {
+                    "$id": "16",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "AffiliatedFaction",
+                    "evaluator": {
+                      "$id": "17",
+                      "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
+                      "compareTo": {
+                        "$id": "18",
+                        "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                        "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                        "actionField": {
+                          "$id": "19",
+                          "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                          "parentType": null,
+                          "AllowSelf": false,
+                          "AllowNull": false,
+                          "criteria": {
+                            "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                            "$values": []
+                          },
+                          "previousField": "{2}:FactionBattleContext:defender",
+                          "previousFieldID": 2,
+                          "value": null,
+                          "delayedValue": null,
+                          "Method": 1,
+                          "ActionFieldID": 0,
+                          "NameID": null,
+                          "ActionFieldIDString": "None",
+                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                        }
+                      },
+                      "propertyName": "AffiliatedFaction",
+                      "Comparator": "==",
+                      "Type": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  }
+                ]
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "value": null,
+              "delayedValue": null,
+              "Method": 0,
+              "ActionFieldID": 4,
+              "NameID": "{4}:GetOrCreateCityAction:actionField",
+              "ActionFieldIDString": "{4}",
+              "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "20",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "21",
+            "$type": "Game.Incidents.GetOrCreateItemAction, Assembly-CSharp",
+            "inventoryToAddTo": {
+              "$id": "22",
+              "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
+              "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "actionField": {
+                "$id": "23",
+                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+                "parentType": null,
+                "AllowSelf": false,
+                "AllowNull": false,
+                "criteria": {
+                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                  "$values": []
+                },
+                "previousField": "{4}:GetOrCreateCityAction:actionField",
+                "previousFieldID": 4,
+                "value": null,
+                "delayedValue": null,
+                "Method": 1,
+                "ActionFieldID": 7,
+                "NameID": "{7}:GetOrCreateItemAction:inventoryToAddTo",
+                "ActionFieldIDString": "{7}",
+                "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+              }
+            },
+            "itemType": "Game.Generators.Items.Trinket, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "findFirst": true,
+            "allowCreate": true,
+            "actionField": {
+              "$id": "24",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Generators.Items.Item, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": [
+                  {
+                    "$id": "25",
+                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                    "propertyName": "Inventory",
+                    "evaluator": {
+                      "$id": "26",
+                      "$type": "Game.Incidents.InventoryEvaluator, Assembly-CSharp",
+                      "compareTo": {
+                        "$id": "27",
+                        "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                        "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                        "actionField": {
+                          "$id": "28",
+                          "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+                          "parentType": null,
+                          "AllowSelf": false,
+                          "AllowNull": false,
+                          "criteria": {
+                            "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                            "$values": []
+                          },
+                          "previousField": "{4}:GetOrCreateCityAction:actionField",
+                          "previousFieldID": 4,
+                          "value": null,
+                          "delayedValue": null,
+                          "Method": 1,
+                          "ActionFieldID": 0,
+                          "NameID": null,
+                          "ActionFieldIDString": "None",
+                          "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                        }
+                      },
+                      "propertyName": "Inventory",
+                      "Comparator": "==",
+                      "Type": "Game.Incidents.Inventory, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "ContextType": "Game.Generators.Items.Item, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    },
+                    "ContextType": "Game.Generators.Items.Item, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "PrimitiveType": "Game.Incidents.Inventory, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  }
+                ]
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "value": null,
+              "delayedValue": null,
+              "Method": 0,
+              "ActionFieldID": 6,
+              "NameID": "{6}:GetOrCreateItemAction:actionField",
+              "ActionFieldIDString": "{6}",
+              "ContextType": "Game.Generators.Items.Item, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        },
+        {
+          "$id": "29",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "30",
+            "$type": "Game.Incidents.BranchingAction, Assembly-CSharp",
+            "branches": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionBranch, Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "31",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "32",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 3,
+                    "container": {
+                      "$id": "33",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": null,
+                      "actionField": null
+                    },
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "34",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "{1} captures {6}.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "35",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "36",
+                            "$type": "Game.Incidents.GetOrCreateCityAction, Assembly-CSharp",
+                            "faction": {
+                              "$id": "37",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": null,
+                              "previousFieldID": -1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 0,
+                              "ActionFieldID": 8,
+                              "NameID": "{8}:GetOrCreateCityAction:faction",
+                              "ActionFieldIDString": "{8}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "location": {
+                              "$id": "38",
+                              "$type": "Game.Incidents.LocationActionField, Assembly-CSharp",
+                              "relatedFaction": null,
+                              "minDistanceFromCities": 0,
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": null,
+                              "previousFieldID": -1,
+                              "value": null,
+                              "delayedValue": null,
+                              "LocationFindMethod": 0,
+                              "FactionCellLocationMethod": 0,
+                              "Method": 0,
+                              "ActionFieldID": 10,
+                              "NameID": "{10}:GetOrCreateCityAction:location",
+                              "ActionFieldIDString": "{10}",
+                              "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "population": {
+                              "$id": "39",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 19,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "wealth": {
+                              "$id": "40",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 8,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "findFirst": true,
+                            "allowCreate": false,
+                            "actionField": {
+                              "$id": "41",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": [
+                                  {
+                                    "$id": "42",
+                                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                                    "propertyName": "AffiliatedFaction",
+                                    "evaluator": {
+                                      "$id": "43",
+                                      "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
+                                      "compareTo": {
+                                        "$id": "44",
+                                        "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                                        "contextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                        "actionField": {
+                                          "$id": "45",
+                                          "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                          "parentType": null,
+                                          "AllowSelf": false,
+                                          "AllowNull": false,
+                                          "criteria": {
+                                            "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                            "$values": []
+                                          },
+                                          "previousField": "{1}:FactionBattleContext:attacker",
+                                          "previousFieldID": 1,
+                                          "value": null,
+                                          "delayedValue": null,
+                                          "Method": 1,
+                                          "ActionFieldID": 0,
+                                          "NameID": null,
+                                          "ActionFieldIDString": "None",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      },
+                                      "propertyName": "AffiliatedFaction",
+                                      "Comparator": "==",
+                                      "Type": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                      "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                    },
+                                    "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "PrimitiveType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                  }
+                                ]
+                              },
+                              "previousField": null,
+                              "previousFieldID": -1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 0,
+                              "ActionFieldID": 9,
+                              "NameID": "{9}:GetOrCreateCityAction:actionField",
+                              "ActionFieldIDString": "{9}",
+                              "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            }
+                          }
+                        },
+                        {
+                          "$id": "46",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "47",
+                            "$type": "Game.Incidents.TradeItemsAction, Assembly-CSharp",
+                            "itemField": {
+                              "$id": "48",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Generators.Items.Item, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{6}:GetOrCreateItemAction:actionField",
+                              "previousFieldID": 6,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 11,
+                              "NameID": "{11}:TradeItemsAction:itemField",
+                              "ActionFieldIDString": "{11}",
+                              "ContextType": "Game.Generators.Items.Item, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "givingInventory": {
+                              "$id": "49",
+                              "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                              "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "actionField": {
+                                "$id": "50",
+                                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+                                "parentType": null,
+                                "AllowSelf": false,
+                                "AllowNull": false,
+                                "criteria": {
+                                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                  "$values": []
+                                },
+                                "previousField": "{4}:GetOrCreateCityAction:actionField",
+                                "previousFieldID": 4,
+                                "value": null,
+                                "delayedValue": null,
+                                "Method": 1,
+                                "ActionFieldID": 12,
+                                "NameID": "{12}:TradeItemsAction:givingInventory",
+                                "ActionFieldIDString": "{12}",
+                                "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                              }
+                            },
+                            "receivingInventory": {
+                              "$id": "51",
+                              "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                              "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "actionField": {
+                                "$id": "52",
+                                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+                                "parentType": null,
+                                "AllowSelf": false,
+                                "AllowNull": false,
+                                "criteria": {
+                                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                  "$values": []
+                                },
+                                "previousField": "{9}:GetOrCreateCityAction:actionField",
+                                "previousFieldID": 9,
+                                "value": null,
+                                "delayedValue": null,
+                                "Method": 1,
+                                "ActionFieldID": 13,
+                                "NameID": "{13}:TradeItemsAction:receivingInventory",
+                                "ActionFieldIDString": "{13}",
+                                "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$id": "53",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "54",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "55",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 14,
+                              "NameID": "{14}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{14}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "56",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "57",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "58",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "59",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 17,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "60",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "61",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 8,
+                                            "max": 11,
+                                            "constant": 0,
+                                            "Value": 10,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 15,
+                                    "NameID": "{EX 15}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "62",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "63",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "64",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 16,
+                              "NameID": "{16}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{16}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "65",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "66",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "67",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "68",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 9,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "69",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "70",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 7,
+                                            "max": 9,
+                                            "constant": 0,
+                                            "Value": 8,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 17,
+                                    "NameID": "{EX 17}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "71",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "72",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 5,
+                    "container": {
+                      "$id": "73",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": null,
+                      "actionField": null
+                    },
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "74",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "{2} forces {1} to retreat.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "75",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "76",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "77",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 18,
+                              "NameID": "{18}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{18}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "78",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "79",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "80",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "81",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 7,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "82",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "83",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 6,
+                                            "max": 8,
+                                            "constant": 0,
+                                            "Value": 6,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 19,
+                                    "NameID": "{EX 19}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "84",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "85",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "86",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 20,
+                              "NameID": "{20}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{20}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "87",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "88",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "89",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "90",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 17,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "91",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "92",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 10,
+                                            "max": 12,
+                                            "constant": 0,
+                                            "Value": 10,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 21,
+                                    "NameID": "{EX 21}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "93",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "94",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 1,
+                    "container": {
+                      "$id": "95",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": null,
+                      "actionField": null
+                    },
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "96",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "Both forces retreat and {6} is lost.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "97",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "98",
+                            "$type": "Game.Incidents.GetOrCreateLandmarkAction, Assembly-CSharp",
+                            "location": {
+                              "$id": "99",
+                              "$type": "Game.Incidents.LocationActionField, Assembly-CSharp",
+                              "relatedFaction": {
+                                "$id": "100",
+                                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                "parentType": null,
+                                "AllowSelf": false,
+                                "AllowNull": false,
+                                "criteria": {
+                                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                  "$values": []
+                                },
+                                "previousField": "{2}:FactionBattleContext:defender",
+                                "previousFieldID": 2,
+                                "value": null,
+                                "delayedValue": null,
+                                "Method": 1,
+                                "ActionFieldID": 0,
+                                "NameID": null,
+                                "ActionFieldIDString": "None",
+                                "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                              },
+                              "minDistanceFromCities": 1,
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": null,
+                              "previousFieldID": -1,
+                              "value": null,
+                              "delayedValue": null,
+                              "LocationFindMethod": 2,
+                              "FactionCellLocationMethod": 0,
+                              "Method": 0,
+                              "ActionFieldID": 23,
+                              "NameID": "{23}:GetOrCreateLandmarkAction:location",
+                              "ActionFieldIDString": "{23}",
+                              "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "findFirst": false,
+                            "allowCreate": true,
+                            "actionField": {
+                              "$id": "101",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Landmark, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": null,
+                              "previousFieldID": -1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 0,
+                              "ActionFieldID": 22,
+                              "NameID": "{22}:GetOrCreateLandmarkAction:actionField",
+                              "ActionFieldIDString": "{22}",
+                              "ContextType": "Game.Incidents.Landmark, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            }
+                          }
+                        },
+                        {
+                          "$id": "102",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "103",
+                            "$type": "Game.Incidents.TradeItemsAction, Assembly-CSharp",
+                            "itemField": {
+                              "$id": "104",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Generators.Items.Item, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{6}:GetOrCreateItemAction:actionField",
+                              "previousFieldID": 6,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 24,
+                              "NameID": "{24}:TradeItemsAction:itemField",
+                              "ActionFieldIDString": "{24}",
+                              "ContextType": "Game.Generators.Items.Item, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "givingInventory": {
+                              "$id": "105",
+                              "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                              "contextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "actionField": {
+                                "$id": "106",
+                                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+                                "parentType": null,
+                                "AllowSelf": false,
+                                "AllowNull": false,
+                                "criteria": {
+                                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                  "$values": []
+                                },
+                                "previousField": "{4}:GetOrCreateCityAction:actionField",
+                                "previousFieldID": 4,
+                                "value": null,
+                                "delayedValue": null,
+                                "Method": 1,
+                                "ActionFieldID": 25,
+                                "NameID": "{25}:TradeItemsAction:givingInventory",
+                                "ActionFieldIDString": "{25}",
+                                "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                              }
+                            },
+                            "receivingInventory": {
+                              "$id": "107",
+                              "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IInventoryAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                              "contextType": "Game.Incidents.Landmark, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "actionField": {
+                                "$id": "108",
+                                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Landmark, Assembly-CSharp]], Assembly-CSharp",
+                                "parentType": null,
+                                "AllowSelf": false,
+                                "AllowNull": false,
+                                "criteria": {
+                                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                  "$values": []
+                                },
+                                "previousField": "{22}:GetOrCreateLandmarkAction:actionField",
+                                "previousFieldID": 22,
+                                "value": null,
+                                "delayedValue": null,
+                                "Method": 1,
+                                "ActionFieldID": 26,
+                                "NameID": "{26}:TradeItemsAction:receivingInventory",
+                                "ActionFieldIDString": "{26}",
+                                "ContextType": "Game.Incidents.Landmark, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$id": "109",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "110",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "111",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{1}:FactionBattleContext:attacker",
+                              "previousFieldID": 1,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 27,
+                              "NameID": "{27}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{27}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "112",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "113",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "114",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "115",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 9,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "116",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "117",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 7,
+                                            "max": 10,
+                                            "constant": 0,
+                                            "Value": 7,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 28,
+                                    "NameID": "{EX 28}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$id": "118",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "119",
+                            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+                            "contextToModify": {
+                              "$id": "120",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "previousField": "{2}:FactionBattleContext:defender",
+                              "previousFieldID": 2,
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 1,
+                              "ActionFieldID": 29,
+                              "NameID": "{29}:ModifyFactionAction:contextToModify",
+                              "ActionFieldIDString": "{29}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "modifiers": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+                              "$values": [
+                                {
+                                  "$id": "121",
+                                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                                  "propertyName": "MilitaryPower",
+                                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                  "Calculator": {
+                                    "$id": "122",
+                                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                                    "propertyName": "MilitaryPower",
+                                    "Operation": "=",
+                                    "expressions": {
+                                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                                      "$values": [
+                                        {
+                                          "$id": "123",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": true,
+                                          "ExpressionType": 2,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": "MilitaryPower",
+                                          "range": {
+                                            "$id": "124",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 0,
+                                            "max": 20,
+                                            "constant": 0,
+                                            "Value": 6,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": "/",
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        },
+                                        {
+                                          "$id": "125",
+                                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                                          "hasNextOperator": false,
+                                          "ExpressionType": 3,
+                                          "constValue": 0,
+                                          "chosenMethod": null,
+                                          "chosenProperty": null,
+                                          "range": {
+                                            "$id": "126",
+                                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                                            "randomRange": true,
+                                            "min": 7,
+                                            "max": 10,
+                                            "constant": 0,
+                                            "Value": 8,
+                                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                          },
+                                          "subexpressions": null,
+                                          "previousCalculatedID": null,
+                                          "rangeWarning": "Range not implemented for non integers!",
+                                          "nextOperator": null,
+                                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      ]
+                                    },
+                                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "ID": 30,
+                                    "NameID": "{EX 30}",
+                                    "AllowMultipleExpressions": true
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.FactionBattleContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Battle_RelicWar.json.meta
+++ b/Assets/Resources/IncidentData/Test_Battle_RelicWar.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eded8d4a852094e49879ac83b94cb936
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_BuildNewCity.json
+++ b/Assets/Resources/IncidentData/Test_Faction_BuildNewCity.json
@@ -1,0 +1,271 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "IncidentName": "Test_Faction_BuildNewCity",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weights": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 2,
+    "Operation": "+",
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "3",
+          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+          "hasNextOperator": true,
+          "ExpressionType": 2,
+          "constValue": 0,
+          "chosenMethod": null,
+          "chosenProperty": "EconomicPriority",
+          "range": {
+            "$id": "4",
+            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+            "randomRange": true,
+            "min": 0,
+            "max": 20,
+            "constant": 0,
+            "Value": 7,
+            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+          },
+          "subexpressions": null,
+          "previousCalculatedID": null,
+          "rangeWarning": "Range not implemented for non integers!",
+          "nextOperator": "/",
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+        },
+        {
+          "$id": "5",
+          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+          "hasNextOperator": false,
+          "ExpressionType": 0,
+          "constValue": 5,
+          "chosenMethod": null,
+          "chosenProperty": null,
+          "range": {
+            "$id": "6",
+            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+            "randomRange": true,
+            "min": 0,
+            "max": 20,
+            "constant": 0,
+            "Value": 17,
+            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+          },
+          "subexpressions": null,
+          "previousCalculatedID": null,
+          "rangeWarning": "Range not implemented for non integers!",
+          "nextOperator": null,
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+        }
+      ]
+    }
+  },
+  "Criteria": {
+    "$id": "7",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "8",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "ControlledTiles",
+          "evaluator": {
+            "$id": "9",
+            "$type": "Game.Incidents.IntegerEvaluator, Assembly-CSharp",
+            "propertyName": "ControlledTiles",
+            "Comparator": ">=",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "10",
+                  "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": true,
+                  "ExpressionType": 2,
+                  "constValue": 0,
+                  "chosenMethod": null,
+                  "chosenProperty": "NumCities",
+                  "range": {
+                    "$id": "11",
+                    "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                    "randomRange": true,
+                    "min": 0,
+                    "max": 20,
+                    "constant": 0,
+                    "Value": 16,
+                    "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": "*",
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "12",
+                  "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": 20,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "13",
+                    "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                    "randomRange": true,
+                    "min": 0,
+                    "max": 20,
+                    "constant": 0,
+                    "Value": 1,
+                    "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        }
+      ]
+    }
+  },
+  "ActionContainer": {
+    "$id": "14",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": null,
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "15",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "16",
+            "$type": "Game.Incidents.GetOrCreateCityAction, Assembly-CSharp",
+            "faction": {
+              "$id": "17",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "value": null,
+              "delayedValue": null,
+              "Method": 1,
+              "ActionFieldID": 1,
+              "NameID": "{1}:GetOrCreateCityAction:faction",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "location": {
+              "$id": "18",
+              "$type": "Game.Incidents.LocationActionField, Assembly-CSharp",
+              "relatedFaction": {
+                "$id": "19",
+                "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                "parentType": null,
+                "AllowSelf": false,
+                "AllowNull": false,
+                "criteria": {
+                  "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                  "$values": []
+                },
+                "previousField": "{0} - Original Context",
+                "previousFieldID": 0,
+                "value": null,
+                "delayedValue": null,
+                "Method": 1,
+                "ActionFieldID": 0,
+                "NameID": null,
+                "ActionFieldIDString": "None",
+                "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+              },
+              "minDistanceFromCities": 3,
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "value": null,
+              "delayedValue": null,
+              "LocationFindMethod": 2,
+              "FactionCellLocationMethod": 0,
+              "Method": 0,
+              "ActionFieldID": 3,
+              "NameID": "{3}:GetOrCreateCityAction:location",
+              "ActionFieldIDString": "{3}",
+              "ContextType": "Game.Incidents.Location, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "population": {
+              "$id": "20",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 10,
+              "max": 20,
+              "constant": 0,
+              "Value": 15,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "21",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 14,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "findFirst": false,
+            "allowCreate": true,
+            "actionField": {
+              "$id": "22",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.City, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": null,
+              "previousFieldID": -1,
+              "value": null,
+              "delayedValue": null,
+              "Method": 0,
+              "ActionFieldID": 2,
+              "NameID": "{2}:GetOrCreateCityAction:actionField",
+              "ActionFieldIDString": "{2}",
+              "ContextType": "Game.Incidents.City, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_BuildNewCity.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_BuildNewCity.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 24ae6b1ef424df14889972b751b839b7
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Faction_GoToWarWhenRelationsBelowThreshold.json
+++ b/Assets/Resources/IncidentData/Test_Faction_GoToWarWhenRelationsBelowThreshold.json
@@ -3,19 +3,28 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Test_Faction_GoToWarWhenRelationsBelowThreshold",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 13,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 13,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "3",
+          "$id": "4",
           "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
           "propertyName": "FactionRelations",
           "evaluator": {
-            "$id": "4",
+            "$id": "5",
             "$type": "Game.Incidents.IntegerValueDictionaryEvaluator, Assembly-CSharp",
             "propertyName": "FactionRelations",
             "Comparator": "<=",
@@ -23,7 +32,7 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "5",
+                  "$id": "6",
                   "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                   "hasNextOperator": false,
                   "ExpressionType": 0,
@@ -31,15 +40,17 @@
                   "chosenMethod": null,
                   "chosenProperty": null,
                   "range": {
-                    "$id": "6",
+                    "$id": "7",
                     "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                     "randomRange": true,
                     "min": 0,
                     "max": 20,
                     "constant": 0,
-                    "Value": 16,
+                    "Value": 7,
                     "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
                   "rangeWarning": "Range not implemented for non integers!",
                   "nextOperator": null,
                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
@@ -54,11 +65,11 @@
           "PrimitiveType": "System.Collections.Generic.Dictionary`2[[Game.Incidents.IIncidentContext, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null],[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
         },
         {
-          "$id": "7",
+          "$id": "8",
           "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
           "propertyName": "AtWar",
           "evaluator": {
-            "$id": "8",
+            "$id": "9",
             "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
             "propertyName": "AtWar",
             "Comparator": "==",
@@ -66,7 +77,7 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "9",
+                  "$id": "10",
                   "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
                   "hasNextOperator": false,
                   "ExpressionType": 0,
@@ -74,11 +85,13 @@
                   "chosenMethod": null,
                   "chosenProperty": null,
                   "range": {
-                    "$id": "10",
+                    "$id": "11",
                     "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
                     "Value": false,
                     "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
                   "rangeWarning": "Range not implemented for non integers!",
                   "nextOperator": null,
                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
@@ -96,20 +109,40 @@
     }
   },
   "ActionContainer": {
-    "$id": "11",
+    "$id": "12",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": "Go to war when relations below threshold.",
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "12",
+          "$id": "13",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "13",
+            "$id": "14",
             "$type": "Game.Incidents.GetOrCreateFactionAction, Assembly-CSharp",
             "population": {
-              "$id": "14",
+              "$id": "15",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 17,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "16",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 16,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "17",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -118,8 +151,8 @@
               "Value": 1,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "influence": {
-              "$id": "15",
+            "politicalPriority": {
+              "$id": "18",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -128,8 +161,8 @@
               "Value": 10,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "wealth": {
-              "$id": "16",
+            "economicPriority": {
+              "$id": "19",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -138,8 +171,8 @@
               "Value": 14,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "politicalPriority": {
-              "$id": "17",
+            "religiousPriority": {
+              "$id": "20",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -148,8 +181,8 @@
               "Value": 2,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "economicPriority": {
-              "$id": "18",
+            "militaryPriority": {
+              "$id": "21",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -158,30 +191,10 @@
               "Value": 6,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "religiousPriority": {
-              "$id": "19",
-              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-              "randomRange": true,
-              "min": 0,
-              "max": 20,
-              "constant": 0,
-              "Value": 1,
-              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-            },
-            "militaryPriority": {
-              "$id": "20",
-              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-              "randomRange": true,
-              "min": 0,
-              "max": 20,
-              "constant": 0,
-              "Value": 7,
-              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-            },
             "findFirst": true,
             "allowCreate": false,
             "actionField": {
-              "$id": "21",
+              "$id": "22",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -190,11 +203,11 @@
                 "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
                 "$values": [
                   {
-                    "$id": "22",
+                    "$id": "23",
                     "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                     "propertyName": "FactionRelations",
                     "evaluator": {
-                      "$id": "23",
+                      "$id": "24",
                       "$type": "Game.Incidents.ActionFieldIntDictionaryEvaluator, Assembly-CSharp",
                       "value": -100,
                       "propertyName": "FactionRelations",
@@ -220,13 +233,13 @@
           }
         },
         {
-          "$id": "24",
+          "$id": "25",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "25",
+            "$id": "26",
             "$type": "Game.Incidents.ChangeWarStateAction, Assembly-CSharp",
             "factionOne": {
-              "$id": "26",
+              "$id": "27",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -246,7 +259,7 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "factionTwo": {
-              "$id": "27",
+              "$id": "28",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -274,7 +287,7 @@
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "28",
+          "$id": "29",
           "$type": "Game.Incidents.ContextDeployer, Assembly-CSharp",
           "delayTime": 0,
           "deploymentCriteria": {
@@ -282,10 +295,10 @@
             "$values": []
           },
           "incidentContext": {
-            "$id": "29",
+            "$id": "30",
             "$type": "Game.Incidents.FactionBattleContext, Assembly-CSharp",
             "attacker": {
-              "$id": "30",
+              "$id": "31",
               "$type": "Game.Incidents.DeployedContextActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.ContextDeployer, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -305,7 +318,7 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "defender": {
-              "$id": "31",
+              "$id": "32",
               "$type": "Game.Incidents.DeployedContextActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.ContextDeployer, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,

--- a/Assets/Resources/IncidentData/Test_Faction_LargeFactionRelationDegradation.json
+++ b/Assets/Resources/IncidentData/Test_Faction_LargeFactionRelationDegradation.json
@@ -3,9 +3,18 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Test_Faction_LargeFactionRelationDegradation",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 2,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 2,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
@@ -13,20 +22,40 @@
     }
   },
   "ActionContainer": {
-    "$id": "3",
+    "$id": "4",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": "Randomly chosen large faction relation degradation.",
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "4",
+          "$id": "5",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "5",
+            "$id": "6",
             "$type": "Game.Incidents.GetOrCreateFactionAction, Assembly-CSharp",
             "population": {
-              "$id": "6",
+              "$id": "7",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 1,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "8",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 7,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "9",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -35,8 +64,8 @@
               "Value": 5,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "influence": {
-              "$id": "7",
+            "politicalPriority": {
+              "$id": "10",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -45,8 +74,8 @@
               "Value": 2,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "wealth": {
-              "$id": "8",
+            "economicPriority": {
+              "$id": "11",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -55,8 +84,8 @@
               "Value": 17,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "politicalPriority": {
-              "$id": "9",
+            "religiousPriority": {
+              "$id": "12",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -65,8 +94,8 @@
               "Value": 15,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "economicPriority": {
-              "$id": "10",
+            "militaryPriority": {
+              "$id": "13",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -75,30 +104,10 @@
               "Value": 10,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "religiousPriority": {
-              "$id": "11",
-              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-              "randomRange": true,
-              "min": 0,
-              "max": 20,
-              "constant": 0,
-              "Value": 0,
-              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-            },
-            "militaryPriority": {
-              "$id": "12",
-              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-              "randomRange": true,
-              "min": 0,
-              "max": 20,
-              "constant": 0,
-              "Value": 19,
-              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-            },
             "findFirst": true,
             "allowCreate": false,
             "actionField": {
-              "$id": "13",
+              "$id": "14",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -120,13 +129,13 @@
           }
         },
         {
-          "$id": "14",
+          "$id": "15",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "15",
+            "$id": "16",
             "$type": "Game.Incidents.ChangeFactionRelationsAction, Assembly-CSharp",
             "affectedFaction": {
-              "$id": "16",
+              "$id": "17",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -146,7 +155,7 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "otherFaction": {
-              "$id": "17",
+              "$id": "18",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -166,13 +175,13 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "amount": {
-              "$id": "18",
+              "$id": "19",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": -40,
               "max": -25,
               "constant": 0,
-              "Value": -29,
+              "Value": -40,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "set": false,

--- a/Assets/Resources/IncidentData/Test_Faction_LargeFactionRelationDegradation.json
+++ b/Assets/Resources/IncidentData/Test_Faction_LargeFactionRelationDegradation.json
@@ -41,7 +41,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 1,
+              "Value": 5,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "influence": {
@@ -51,7 +51,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 7,
+              "Value": 6,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "wealth": {
@@ -61,7 +61,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 5,
+              "Value": 12,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "politicalPriority": {
@@ -71,7 +71,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 2,
+              "Value": 10,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "economicPriority": {
@@ -81,7 +81,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 17,
+              "Value": 18,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "religiousPriority": {
@@ -91,7 +91,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 15,
+              "Value": 9,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "militaryPriority": {
@@ -101,7 +101,7 @@
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 10,
+              "Value": 12,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "findFirst": true,
@@ -181,7 +181,7 @@
               "min": -40,
               "max": -25,
               "constant": 0,
-              "Value": -40,
+              "Value": -34,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "set": false,

--- a/Assets/Resources/IncidentData/Test_Faction_MakePeace.json
+++ b/Assets/Resources/IncidentData/Test_Faction_MakePeace.json
@@ -6,7 +6,7 @@
   "Weights": {
     "$id": "2",
     "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
-    "baseWeight": 1,
+    "baseWeight": 8,
     "Operation": null,
     "expressions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",

--- a/Assets/Resources/IncidentData/Test_Faction_MakePeace.json
+++ b/Assets/Resources/IncidentData/Test_Faction_MakePeace.json
@@ -3,19 +3,28 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Test_Faction_MakePeace",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 1,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 1,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "3",
+          "$id": "4",
           "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
           "propertyName": "AtWar",
           "evaluator": {
-            "$id": "4",
+            "$id": "5",
             "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
             "propertyName": "AtWar",
             "Comparator": "==",
@@ -23,7 +32,7 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "5",
+                  "$id": "6",
                   "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
                   "hasNextOperator": false,
                   "ExpressionType": 0,
@@ -31,11 +40,13 @@
                   "chosenMethod": null,
                   "chosenProperty": null,
                   "range": {
-                    "$id": "6",
+                    "$id": "7",
                     "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
                     "Value": false,
                     "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
                   "rangeWarning": "Range not implemented for non integers!",
                   "nextOperator": null,
                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
@@ -50,11 +61,11 @@
           "PrimitiveType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
         },
         {
-          "$id": "7",
+          "$id": "8",
           "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
           "propertyName": "CouldMakePeace",
           "evaluator": {
-            "$id": "8",
+            "$id": "9",
             "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
             "propertyName": "CouldMakePeace",
             "Comparator": "==",
@@ -62,7 +73,7 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "9",
+                  "$id": "10",
                   "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
                   "hasNextOperator": false,
                   "ExpressionType": 0,
@@ -70,11 +81,13 @@
                   "chosenMethod": null,
                   "chosenProperty": null,
                   "range": {
-                    "$id": "10",
+                    "$id": "11",
                     "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
                     "Value": false,
                     "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
                   "rangeWarning": "Range not implemented for non integers!",
                   "nextOperator": null,
                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
@@ -92,20 +105,20 @@
     }
   },
   "ActionContainer": {
-    "$id": "11",
+    "$id": "12",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": "Improved relations lead to peace between {0} and {2}.",
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "12",
+          "$id": "13",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "13",
+            "$id": "14",
             "$type": "Game.Incidents.ChangeWarStateAction, Assembly-CSharp",
             "factionOne": {
-              "$id": "14",
+              "$id": "15",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -125,7 +138,7 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "factionTwo": {
-              "$id": "15",
+              "$id": "16",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -134,11 +147,11 @@
                 "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
                 "$values": [
                   {
-                    "$id": "16",
+                    "$id": "17",
                     "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                     "propertyName": "FactionRelations",
                     "evaluator": {
-                      "$id": "17",
+                      "$id": "18",
                       "$type": "Game.Incidents.ActionFieldIntDictionaryEvaluator, Assembly-CSharp",
                       "value": 0,
                       "propertyName": "FactionRelations",

--- a/Assets/Resources/IncidentData/Test_Faction_MediumFactionRelationDegradation.json
+++ b/Assets/Resources/IncidentData/Test_Faction_MediumFactionRelationDegradation.json
@@ -3,9 +3,18 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Test_Faction_MediumFactionRelationDegradation",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 3,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 3,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
@@ -13,20 +22,20 @@
     }
   },
   "ActionContainer": {
-    "$id": "3",
+    "$id": "4",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": "Randomly chosen medium faction relation degradation.",
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "4",
+          "$id": "5",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "5",
+            "$id": "6",
             "$type": "Game.Incidents.ChangeFactionRelationsAction, Assembly-CSharp",
             "affectedFaction": {
-              "$id": "6",
+              "$id": "7",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -46,7 +55,7 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "otherFaction": {
-              "$id": "7",
+              "$id": "8",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -66,13 +75,13 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "amount": {
-              "$id": "8",
+              "$id": "9",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": -25,
               "max": -15,
               "constant": 0,
-              "Value": -19,
+              "Value": -16,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "set": false,

--- a/Assets/Resources/IncidentData/Test_Faction_MiraculousPeaceTreaty.json
+++ b/Assets/Resources/IncidentData/Test_Faction_MiraculousPeaceTreaty.json
@@ -3,19 +3,28 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Test_Faction_MiraculousPeaceTreaty",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 1,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 1,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "3",
+          "$id": "4",
           "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
           "propertyName": "AtWar",
           "evaluator": {
-            "$id": "4",
+            "$id": "5",
             "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
             "propertyName": "AtWar",
             "Comparator": "==",
@@ -23,7 +32,7 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "5",
+                  "$id": "6",
                   "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
                   "hasNextOperator": false,
                   "ExpressionType": 0,
@@ -31,11 +40,13 @@
                   "chosenMethod": null,
                   "chosenProperty": null,
                   "range": {
-                    "$id": "6",
+                    "$id": "7",
                     "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
                     "Value": false,
                     "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
                   "rangeWarning": "Range not implemented for non integers!",
                   "nextOperator": null,
                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
@@ -53,20 +64,20 @@
     }
   },
   "ActionContainer": {
-    "$id": "7",
+    "$id": "8",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": "Miraculous peace treaty between {0} and {2}.",
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "8",
+          "$id": "9",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "9",
+            "$id": "10",
             "$type": "Game.Incidents.ChangeWarStateAction, Assembly-CSharp",
             "factionOne": {
-              "$id": "10",
+              "$id": "11",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -86,7 +97,7 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "factionTwo": {
-              "$id": "11",
+              "$id": "12",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -95,11 +106,11 @@
                 "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
                 "$values": [
                   {
-                    "$id": "12",
+                    "$id": "13",
                     "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                     "propertyName": "FactionsAtWarWith",
                     "evaluator": {
-                      "$id": "13",
+                      "$id": "14",
                       "$type": "Game.Incidents.ActionFieldListContainsEvaluator, Assembly-CSharp",
                       "propertyName": "FactionsAtWarWith",
                       "Comparator": "==",
@@ -125,13 +136,13 @@
           }
         },
         {
-          "$id": "14",
+          "$id": "15",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "15",
+            "$id": "16",
             "$type": "Game.Incidents.ChangeFactionRelationsAction, Assembly-CSharp",
             "affectedFaction": {
-              "$id": "16",
+              "$id": "17",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -151,7 +162,7 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "otherFaction": {
-              "$id": "17",
+              "$id": "18",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -171,7 +182,7 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "amount": {
-              "$id": "18",
+              "$id": "19",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": false,
               "min": 0,

--- a/Assets/Resources/IncidentData/Test_Faction_RandomFactionInfluenceChange.json
+++ b/Assets/Resources/IncidentData/Test_Faction_RandomFactionInfluenceChange.json
@@ -3,9 +3,18 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Test_Faction_RandomFactionInfluenceChange",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 5,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 5,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
@@ -13,20 +22,20 @@
     }
   },
   "ActionContainer": {
-    "$id": "3",
+    "$id": "4",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": null,
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "4",
+          "$id": "5",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "5",
+            "$id": "6",
             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
             "contextToModify": {
-              "$id": "6",
+              "$id": "7",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -49,11 +58,13 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "7",
+                  "$id": "8",
                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                   "propertyName": "Influence",
-                  "calculator": {
-                    "$id": "8",
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                  "Calculator": {
+                    "$id": "9",
                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                     "propertyName": "Influence",
                     "Operation": "+",
@@ -61,7 +72,7 @@
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "9",
+                          "$id": "10",
                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                           "hasNextOperator": false,
                           "ExpressionType": 3,
@@ -69,27 +80,29 @@
                           "chosenMethod": null,
                           "chosenProperty": null,
                           "range": {
-                            "$id": "10",
+                            "$id": "11",
                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                             "randomRange": true,
                             "min": -10,
                             "max": 10,
                             "constant": 0,
-                            "Value": -8,
+                            "Value": 5,
                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                           },
+                          "subexpressions": null,
+                          "previousCalculatedID": null,
                           "rangeWarning": "Range not implemented for non integers!",
                           "nextOperator": null,
                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                         }
                       ]
                     },
-                    "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "ID": 2,
+                    "NameID": "{EX 2}",
                     "AllowMultipleExpressions": true
-                  },
-                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  }
                 }
               ]
             }

--- a/Assets/Resources/IncidentData/Test_Faction_RandomFactionWealthChange.json
+++ b/Assets/Resources/IncidentData/Test_Faction_RandomFactionWealthChange.json
@@ -3,9 +3,18 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Test_Faction_RandomFactionWealthChange",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 5,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 5,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
@@ -13,20 +22,20 @@
     }
   },
   "ActionContainer": {
-    "$id": "3",
+    "$id": "4",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": null,
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "4",
+          "$id": "5",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "5",
+            "$id": "6",
             "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
             "contextToModify": {
-              "$id": "6",
+              "$id": "7",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -49,11 +58,13 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "7",
+                  "$id": "8",
                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
                   "propertyName": "Wealth",
-                  "calculator": {
-                    "$id": "8",
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                  "Calculator": {
+                    "$id": "9",
                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                     "propertyName": "Wealth",
                     "Operation": "+",
@@ -61,7 +72,7 @@
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "9",
+                          "$id": "10",
                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                           "hasNextOperator": false,
                           "ExpressionType": 3,
@@ -69,27 +80,29 @@
                           "chosenMethod": null,
                           "chosenProperty": null,
                           "range": {
-                            "$id": "10",
+                            "$id": "11",
                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                             "randomRange": true,
                             "min": -20,
                             "max": 20,
                             "constant": 0,
-                            "Value": -2,
+                            "Value": 6,
                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                           },
+                          "subexpressions": null,
+                          "previousCalculatedID": null,
                           "rangeWarning": "Range not implemented for non integers!",
                           "nextOperator": null,
                           "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                         }
                       ]
                     },
-                    "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                     "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "ID": 2,
+                    "NameID": "{EX 2}",
                     "AllowMultipleExpressions": true
-                  },
-                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  }
                 }
               ]
             }

--- a/Assets/Resources/IncidentData/Test_Faction_RelationsImproveWhileAtWar.json
+++ b/Assets/Resources/IncidentData/Test_Faction_RelationsImproveWhileAtWar.json
@@ -3,19 +3,28 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Test_Faction_RelationsImproveWhileAtWar",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 3,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 3,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "3",
+          "$id": "4",
           "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
           "propertyName": "AtWar",
           "evaluator": {
-            "$id": "4",
+            "$id": "5",
             "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
             "propertyName": "AtWar",
             "Comparator": "==",
@@ -23,7 +32,7 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "5",
+                  "$id": "6",
                   "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
                   "hasNextOperator": false,
                   "ExpressionType": 0,
@@ -31,11 +40,13 @@
                   "chosenMethod": null,
                   "chosenProperty": null,
                   "range": {
-                    "$id": "6",
+                    "$id": "7",
                     "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
                     "Value": false,
                     "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
                   "rangeWarning": "Range not implemented for non integers!",
                   "nextOperator": null,
                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
@@ -53,20 +64,20 @@
     }
   },
   "ActionContainer": {
-    "$id": "7",
+    "$id": "8",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": "Relations imrpove between {0} and {2}.",
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "8",
+          "$id": "9",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "9",
+            "$id": "10",
             "$type": "Game.Incidents.ChangeFactionRelationsAction, Assembly-CSharp",
             "affectedFaction": {
-              "$id": "10",
+              "$id": "11",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -86,7 +97,7 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "otherFaction": {
-              "$id": "11",
+              "$id": "12",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -95,11 +106,11 @@
                 "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
                 "$values": [
                   {
-                    "$id": "12",
+                    "$id": "13",
                     "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                     "propertyName": "FactionsAtWarWith",
                     "evaluator": {
-                      "$id": "13",
+                      "$id": "14",
                       "$type": "Game.Incidents.ActionFieldListContainsEvaluator, Assembly-CSharp",
                       "propertyName": "FactionsAtWarWith",
                       "Comparator": "==",
@@ -122,13 +133,13 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "amount": {
-              "$id": "14",
+              "$id": "15",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 20,
               "max": 40,
               "constant": 120,
-              "Value": 38,
+              "Value": 22,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "set": false,

--- a/Assets/Resources/IncidentData/Test_Faction_SendBattleContextIfAtWar.json
+++ b/Assets/Resources/IncidentData/Test_Faction_SendBattleContextIfAtWar.json
@@ -3,19 +3,28 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Test_Faction_SendBattleContextIfAtWar",
   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 7,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 7,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "3",
+          "$id": "4",
           "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
           "propertyName": "AtWar",
           "evaluator": {
-            "$id": "4",
+            "$id": "5",
             "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
             "propertyName": "AtWar",
             "Comparator": "==",
@@ -23,7 +32,7 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "5",
+                  "$id": "6",
                   "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
                   "hasNextOperator": false,
                   "ExpressionType": 0,
@@ -31,11 +40,13 @@
                   "chosenMethod": null,
                   "chosenProperty": null,
                   "range": {
-                    "$id": "6",
+                    "$id": "7",
                     "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
                     "Value": false,
                     "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                   },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
                   "rangeWarning": "Range not implemented for non integers!",
                   "nextOperator": null,
                   "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
@@ -53,20 +64,40 @@
     }
   },
   "ActionContainer": {
-    "$id": "7",
+    "$id": "8",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": "Sent battle context because at war.",
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "8",
+          "$id": "9",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "9",
+            "$id": "10",
             "$type": "Game.Incidents.GetOrCreateFactionAction, Assembly-CSharp",
             "population": {
-              "$id": "10",
+              "$id": "11",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 9,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "influence": {
+              "$id": "12",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 18,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "wealth": {
+              "$id": "13",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -75,8 +106,8 @@
               "Value": 5,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "influence": {
-              "$id": "11",
+            "politicalPriority": {
+              "$id": "14",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
@@ -85,37 +116,7 @@
               "Value": 8,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "wealth": {
-              "$id": "12",
-              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-              "randomRange": true,
-              "min": 0,
-              "max": 20,
-              "constant": 0,
-              "Value": 12,
-              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-            },
-            "politicalPriority": {
-              "$id": "13",
-              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-              "randomRange": true,
-              "min": 0,
-              "max": 20,
-              "constant": 0,
-              "Value": 13,
-              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-            },
             "economicPriority": {
-              "$id": "14",
-              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
-              "randomRange": true,
-              "min": 0,
-              "max": 20,
-              "constant": 0,
-              "Value": 13,
-              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-            },
-            "religiousPriority": {
               "$id": "15",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
@@ -125,20 +126,30 @@
               "Value": 12,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
-            "militaryPriority": {
+            "religiousPriority": {
               "$id": "16",
               "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
               "randomRange": true,
               "min": 0,
               "max": 20,
               "constant": 0,
-              "Value": 0,
+              "Value": 13,
+              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+            },
+            "militaryPriority": {
+              "$id": "17",
+              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+              "randomRange": true,
+              "min": 0,
+              "max": 20,
+              "constant": 0,
+              "Value": 13,
               "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             },
             "findFirst": true,
             "allowCreate": false,
             "actionField": {
-              "$id": "17",
+              "$id": "18",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -147,11 +158,11 @@
                 "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
                 "$values": [
                   {
-                    "$id": "18",
+                    "$id": "19",
                     "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
                     "propertyName": "FactionsAtWarWith",
                     "evaluator": {
-                      "$id": "19",
+                      "$id": "20",
                       "$type": "Game.Incidents.ActionFieldListContainsEvaluator, Assembly-CSharp",
                       "propertyName": "FactionsAtWarWith",
                       "Comparator": "==",
@@ -181,7 +192,7 @@
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "20",
+          "$id": "21",
           "$type": "Game.Incidents.ContextDeployer, Assembly-CSharp",
           "delayTime": 0,
           "deploymentCriteria": {
@@ -189,10 +200,10 @@
             "$values": []
           },
           "incidentContext": {
-            "$id": "21",
+            "$id": "22",
             "$type": "Game.Incidents.FactionBattleContext, Assembly-CSharp",
             "attacker": {
-              "$id": "22",
+              "$id": "23",
               "$type": "Game.Incidents.DeployedContextActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.ContextDeployer, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -212,7 +223,7 @@
               "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
             },
             "defender": {
-              "$id": "23",
+              "$id": "24",
               "$type": "Game.Incidents.DeployedContextActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.ContextDeployer, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,

--- a/Assets/Resources/IncidentData/Test_Faction_TrainMilitary.json
+++ b/Assets/Resources/IncidentData/Test_Faction_TrainMilitary.json
@@ -1,0 +1,214 @@
+{
+  "$id": "1",
+  "$type": "Game.Incidents.Incident, Assembly-CSharp",
+  "IncidentName": "Test_Faction_TrainMilitary",
+  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+  "Weights": {
+    "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 1,
+    "Operation": "+",
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "3",
+          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+          "hasNextOperator": false,
+          "ExpressionType": 2,
+          "constValue": 0,
+          "chosenMethod": null,
+          "chosenProperty": "MilitaryPriority",
+          "range": {
+            "$id": "4",
+            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+            "randomRange": true,
+            "min": 0,
+            "max": 20,
+            "constant": 0,
+            "Value": 14,
+            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+          },
+          "subexpressions": null,
+          "previousCalculatedID": null,
+          "rangeWarning": "Range not implemented for non integers!",
+          "nextOperator": null,
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+        }
+      ]
+    }
+  },
+  "Criteria": {
+    "$id": "5",
+    "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
+    "criteria": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "6",
+          "$type": "Game.Incidents.IncidentCriteria, Assembly-CSharp",
+          "propertyName": "MilitaryPower",
+          "evaluator": {
+            "$id": "7",
+            "$type": "Game.Incidents.IntegerEvaluator, Assembly-CSharp",
+            "propertyName": "MilitaryPower",
+            "Comparator": "<=",
+            "expressions": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "8",
+                  "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": true,
+                  "ExpressionType": 2,
+                  "constValue": 0,
+                  "chosenMethod": null,
+                  "chosenProperty": "Population",
+                  "range": {
+                    "$id": "9",
+                    "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                    "randomRange": true,
+                    "min": 0,
+                    "max": 20,
+                    "constant": 0,
+                    "Value": 11,
+                    "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": "/",
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "10",
+                  "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                  "hasNextOperator": false,
+                  "ExpressionType": 0,
+                  "constValue": 10,
+                  "chosenMethod": null,
+                  "chosenProperty": null,
+                  "range": {
+                    "$id": "11",
+                    "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                    "randomRange": true,
+                    "min": 0,
+                    "max": 20,
+                    "constant": 0,
+                    "Value": 2,
+                    "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  },
+                  "subexpressions": null,
+                  "previousCalculatedID": null,
+                  "rangeWarning": "Range not implemented for non integers!",
+                  "nextOperator": null,
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
+            },
+            "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "AllowMultipleExpressions": true
+          },
+          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+        }
+      ]
+    }
+  },
+  "ActionContainer": {
+    "$id": "12",
+    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+    "incidentLog": "{0} trains troops.",
+    "Actions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+      "$values": [
+        {
+          "$id": "13",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "14",
+            "$type": "Game.Incidents.ModifyFactionAction, Assembly-CSharp",
+            "contextToModify": {
+              "$id": "15",
+              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+              "parentType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+              "AllowSelf": false,
+              "AllowNull": false,
+              "criteria": {
+                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                "$values": []
+              },
+              "previousField": "{0} - Original Context",
+              "previousFieldID": 0,
+              "value": null,
+              "delayedValue": null,
+              "Method": 1,
+              "ActionFieldID": 1,
+              "NameID": "{1}:ModifyFactionAction:contextToModify",
+              "ActionFieldIDString": "{1}",
+              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+            },
+            "modifiers": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "16",
+                  "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                  "propertyName": "MilitaryPower",
+                  "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                  "Calculator": {
+                    "$id": "17",
+                    "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
+                    "propertyName": "MilitaryPower",
+                    "Operation": "+",
+                    "expressions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "18",
+                          "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
+                          "hasNextOperator": false,
+                          "ExpressionType": 3,
+                          "constValue": 0,
+                          "chosenMethod": null,
+                          "chosenProperty": null,
+                          "range": {
+                            "$id": "19",
+                            "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                            "randomRange": true,
+                            "min": 2,
+                            "max": 5,
+                            "constant": 0,
+                            "Value": 4,
+                            "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                          },
+                          "subexpressions": null,
+                          "previousCalculatedID": null,
+                          "rangeWarning": "Range not implemented for non integers!",
+                          "nextOperator": null,
+                          "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                        }
+                      ]
+                    },
+                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "ID": 2,
+                    "NameID": "{EX 2}",
+                    "AllowMultipleExpressions": true
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Deployers": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+      "$values": []
+    },
+    "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+  }
+}

--- a/Assets/Resources/IncidentData/Test_Faction_TrainMilitary.json.meta
+++ b/Assets/Resources/IncidentData/Test_Faction_TrainMilitary.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 36c64b17fbd556a479858a6de56e42b6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/IncidentData/Test_Person_RandomModifyPersonInfluence.json
+++ b/Assets/Resources/IncidentData/Test_Person_RandomModifyPersonInfluence.json
@@ -3,9 +3,18 @@
   "$type": "Game.Incidents.Incident, Assembly-CSharp",
   "IncidentName": "Test_Person_RandomModifyPersonInfluence",
   "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-  "Weight": 5,
-  "Criteria": {
+  "Weights": {
     "$id": "2",
+    "$type": "Game.Incidents.IncidentWeight`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+    "baseWeight": 5,
+    "Operation": null,
+    "expressions": {
+      "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
+      "$values": []
+    }
+  },
+  "Criteria": {
+    "$id": "3",
     "$type": "Game.Incidents.IncidentCriteriaContainer, Assembly-CSharp",
     "criteria": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IIncidentCriteria, Assembly-CSharp]], mscorlib",
@@ -13,20 +22,20 @@
     }
   },
   "ActionContainer": {
-    "$id": "3",
+    "$id": "4",
     "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
     "incidentLog": null,
     "Actions": {
       "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
       "$values": [
         {
-          "$id": "4",
+          "$id": "5",
           "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
           "incidentAction": {
-            "$id": "5",
+            "$id": "6",
             "$type": "Game.Incidents.ModifyPersonAction, Assembly-CSharp",
             "contextToModify": {
-              "$id": "6",
+              "$id": "7",
               "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
               "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
               "AllowSelf": false,
@@ -49,11 +58,13 @@
               "$type": "System.Collections.Generic.List`1[[Game.Incidents.ContextModifier`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp]], mscorlib",
               "$values": [
                 {
-                  "$id": "7",
+                  "$id": "8",
                   "$type": "Game.Incidents.ContextModifier`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
                   "propertyName": "Influence",
-                  "calculator": {
-                    "$id": "8",
+                  "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                  "Calculator": {
+                    "$id": "9",
                     "$type": "Game.Incidents.IntegerContextModifierCalculator, Assembly-CSharp",
                     "propertyName": "Influence",
                     "Operation": "+",
@@ -61,7 +72,7 @@
                       "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp]], mscorlib",
                       "$values": [
                         {
-                          "$id": "9",
+                          "$id": "10",
                           "$type": "Game.Incidents.Expression`1[[System.Int32, mscorlib]], Assembly-CSharp",
                           "hasNextOperator": false,
                           "ExpressionType": 3,
@@ -69,27 +80,29 @@
                           "chosenMethod": null,
                           "chosenProperty": null,
                           "range": {
-                            "$id": "10",
+                            "$id": "11",
                             "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
                             "randomRange": true,
                             "min": -5,
                             "max": 5,
                             "constant": 0,
-                            "Value": 2,
+                            "Value": 1,
                             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
                           },
+                          "subexpressions": null,
+                          "previousCalculatedID": null,
                           "rangeWarning": "Range not implemented for non integers!",
                           "nextOperator": null,
                           "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
                         }
                       ]
                     },
-                    "Type": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                     "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    "ID": 2,
+                    "NameID": "{EX 2}",
                     "AllowMultipleExpressions": true
-                  },
-                  "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
-                  "PrimitiveType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                  }
                 }
               ]
             }

--- a/Assets/Scripts/Data/SimRandom.cs
+++ b/Assets/Scripts/Data/SimRandom.cs
@@ -19,6 +19,10 @@ public static class SimRandom
 
     public static int RandomRange(int minValue, int maxValue)
     {
+        if(minValue >= maxValue)
+		{
+            OutputLogger.LogError(string.Format("{0} isnt less than {1}!", minValue, maxValue));
+		}
         return rand.Next(minValue, maxValue);
     }
 

--- a/Assets/Scripts/Generators/Items/Item.cs
+++ b/Assets/Scripts/Generators/Items/Item.cs
@@ -6,9 +6,11 @@ using System.Reflection;
 
 namespace Game.Generators.Items
 {
-	abstract public class Item : InertIncidentContext
+	abstract public class Item : InertIncidentContext, IInventoryAffiliated
 	{
 		public override Type ContextType => typeof(Item);
+
+		public Inventory Inventory { get; set; }
 	}
 
 	[System.Serializable]

--- a/Assets/Scripts/Incidents/ContextDeployer.cs
+++ b/Assets/Scripts/Incidents/ContextDeployer.cs
@@ -155,6 +155,10 @@ namespace Game.Incidents
 
 		public void DeployContext() { }
 
+		public void Die()
+		{
+		}
+
 		public DataTable GetDataTable()
 		{
 			return null;

--- a/Assets/Scripts/Incidents/Contexts/City.cs
+++ b/Assets/Scripts/Incidents/Contexts/City.cs
@@ -13,11 +13,12 @@ namespace Game.Incidents
 		public Faction AffiliatedFaction { get; set; }
 		public int Population { get; set; }
 		public int Wealth { get; set; }
+		public int NumItems => Inventory.Items.Count;
 		public bool IsOnBorder => SimulationUtilities.FindBorderWithinFaction(AffiliatedFaction).Contains(CurrentLocation.TileIndex);
 		public List<Resource> Resources { get; set; }
 		public List<Landmark> Landmarks { get; set; }
 
-		public List<Item> Inventory { get; set; }
+		public Inventory Inventory { get; set; }
 
 		public City(Faction faction, Location location, int population, int wealth)
 		{
@@ -25,7 +26,7 @@ namespace Game.Incidents
 			CurrentLocation = location;
 			Population = population;
 			Wealth = wealth;
-			Inventory = new List<Item>();
+			Inventory = new Inventory();
 		}
 
 		public int GenerateWealth()

--- a/Assets/Scripts/Incidents/Contexts/City.cs
+++ b/Assets/Scripts/Incidents/Contexts/City.cs
@@ -13,6 +13,7 @@ namespace Game.Incidents
 		public Faction AffiliatedFaction { get; set; }
 		public int Population { get; set; }
 		public int Wealth { get; set; }
+		public bool IsOnBorder => SimulationUtilities.FindBorderWithinFaction(AffiliatedFaction).Contains(CurrentLocation.TileIndex);
 		public List<Resource> Resources { get; set; }
 		public List<Landmark> Landmarks { get; set; }
 

--- a/Assets/Scripts/Incidents/Contexts/City.cs
+++ b/Assets/Scripts/Incidents/Contexts/City.cs
@@ -1,5 +1,6 @@
 ﻿using Game.Generators.Items;
 using Game.Incidents;
+using Game.Simulation;
 using System;
 using System.Collections.Generic;
 

--- a/Assets/Scripts/Incidents/Contexts/ContextInterfaces/IInventoryAffiliated.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextInterfaces/IInventoryAffiliated.cs
@@ -5,6 +5,6 @@ namespace Game.Incidents
 {
 	public interface IInventoryAffiliated
 	{
-		List<Item> Inventory { get; }
+		Inventory Inventory { get; }
 	}
 }

--- a/Assets/Scripts/Incidents/Contexts/ContextModifiers/BooleanContextModifierCalculator.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextModifiers/BooleanContextModifierCalculator.cs
@@ -9,5 +9,10 @@ namespace Game.Incidents
         {
             Operators = ExpressionHelpers.BoolOperators;
         }
-    }
+
+		protected override bool Clamp(bool value)
+		{
+			return value;
+		}
+	}
 }

--- a/Assets/Scripts/Incidents/Contexts/ContextModifiers/ContextModifier.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextModifiers/ContextModifier.cs
@@ -5,7 +5,13 @@ using System.Linq;
 
 namespace Game.Incidents
 {
-	public class ContextModifier<T>
+    public interface IContextModifier
+    {
+        [ShowInInspector]
+        IContextModifierCalculator Calculator { get; set; }
+        void Modify(IIncidentContext context);
+    }
+	public class ContextModifier<T> : IContextModifier
 	{
 		public Type ContextType => typeof(T);
 		public Type PrimitiveType { get; set; }
@@ -14,8 +20,8 @@ namespace Game.Incidents
 		[ValueDropdown("GetPropertyNames"), OnValueChanged("SetPrimitiveType"), HorizontalGroup("Group 1")]
 		public string propertyName;
 
-        [ShowIfGroup("PropertyChosen"), HideReferenceObjectPicker]
-        public IContextModifierCalculator calculator;
+        [ShowInInspector, ShowIfGroup("PropertyChosen"), HideReferenceObjectPicker]
+        public IContextModifierCalculator Calculator { get; set; }
 
         private bool PropertyChosen => propertyName != null;
 
@@ -26,7 +32,7 @@ namespace Game.Incidents
 
         public void Modify(IIncidentContext context)
 		{
-            calculator.Calculate(context);
+            Calculator.Calculate(context);
 		}
 
         private void GetPropertyList()
@@ -68,16 +74,17 @@ namespace Game.Incidents
 
             if (PrimitiveType == typeof(int))
             {
-                calculator = new IntegerContextModifierCalculator(propertyName, ContextType);
+                Calculator = new IntegerContextModifierCalculator(propertyName, ContextType);
             }
             else if (PrimitiveType == typeof(float))
             {
-                calculator = new FloatContextModifierCalculator(propertyName, ContextType);
+                Calculator = new FloatContextModifierCalculator(propertyName, ContextType);
             }
             else if (PrimitiveType == typeof(bool))
             {
-                calculator = new BooleanContextModifierCalculator(propertyName, ContextType);
+                Calculator = new BooleanContextModifierCalculator(propertyName, ContextType);
             }
+            IncidentEditorWindow.UpdateActionFieldIDs();
         }
     }
 }

--- a/Assets/Scripts/Incidents/Contexts/ContextModifiers/ContextModifierCalculator.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextModifiers/ContextModifierCalculator.cs
@@ -26,6 +26,8 @@ namespace Game.Incidents
         [ListDrawerSettings(CustomAddFunction = "AddNewExpression"), HorizontalGroup("Group 1"), HideReferenceObjectPicker]
         public List<Expression<T>> expressions;
 
+        public bool clamped = true;
+
         virtual public bool AllowMultipleExpressions => true;
 
         public ContextModifierCalculator()
@@ -48,6 +50,10 @@ namespace Game.Incidents
             var combinedExpressions = CombineExpressions(context);
             IncidentService.Instance.currentExpressionValues.Add(NameID, new ExpressionValue(combinedExpressions));
             var calculatedValue = Operators[Operation].Invoke(propertyValue, combinedExpressions);
+            if(clamped)
+			{
+                calculatedValue = Clamp(calculatedValue);
+			}
             property.SetValue(context, calculatedValue);
         }
         public T CombineExpressions(IIncidentContext context)
@@ -56,6 +62,8 @@ namespace Game.Incidents
         }
 
         abstract public void Setup();
+
+        abstract protected T Clamp(T value);
 
         private void AddNewExpression()
         {

--- a/Assets/Scripts/Incidents/Contexts/ContextModifiers/ContextModifierCalculator.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextModifiers/ContextModifierCalculator.cs
@@ -47,12 +47,7 @@ namespace Game.Incidents
         }
         public T CombineExpressions(IIncidentContext context)
         {
-            var currentValue = expressions[0].GetValue(context);
-            for (int i = 0; i < expressions.Count - 1; i++)
-            {
-                currentValue = Operators[expressions[i].nextOperator].Invoke(currentValue, expressions[i + 1].GetValue(context));
-            }
-            return currentValue;
+            return Expression<T>.CombineExpressions(context, expressions, Operators);
         }
 
         abstract public void Setup();

--- a/Assets/Scripts/Incidents/Contexts/ContextModifiers/ContextModifierCalculator.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextModifiers/ContextModifierCalculator.cs
@@ -9,8 +9,11 @@ namespace Game.Incidents
 	public abstract class ContextModifierCalculator<T> : IContextModifierCalculator
     {
         [HideInInspector]
-        public Type Type => typeof(T);
+        public Type PrimitiveType => typeof(T);
         public Type ContextType { get; set; }
+        public int ID { get; set; }
+        [ReadOnly, ShowInInspector]
+        public string NameID => "{EX " + ID + "}";
 
         protected Dictionary<string, Func<T, T, T>> Operators { get; set; }
 
@@ -42,7 +45,9 @@ namespace Game.Incidents
         {
             var property = context.GetType().GetProperty(propertyName);
             var propertyValue = (T)property.GetValue(context);
-            var calculatedValue = Operators[Operation].Invoke(propertyValue, CombineExpressions(context));
+            var combinedExpressions = CombineExpressions(context);
+            IncidentService.Instance.currentExpressionValues.Add(NameID, new ExpressionValue(combinedExpressions));
+            var calculatedValue = Operators[Operation].Invoke(propertyValue, combinedExpressions);
             property.SetValue(context, calculatedValue);
         }
         public T CombineExpressions(IIncidentContext context)

--- a/Assets/Scripts/Incidents/Contexts/ContextModifiers/FloatContextModifierCalculator.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextModifiers/FloatContextModifierCalculator.cs
@@ -9,5 +9,10 @@ namespace Game.Incidents
         {
             Operators = ExpressionHelpers.FloatOperators;
         }
-    }
+
+		protected override float Clamp(float value)
+		{
+			return value < 0 ? 0 : value;
+		}
+	}
 }

--- a/Assets/Scripts/Incidents/Contexts/ContextModifiers/IContextModifierCalculator.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextModifiers/IContextModifierCalculator.cs
@@ -1,7 +1,12 @@
-﻿namespace Game.Incidents
+﻿using System;
+
+namespace Game.Incidents
 {
 	public interface IContextModifierCalculator
     {
+        Type PrimitiveType { get; }
+        int ID { get; set; }
+        string NameID { get; }
         void Calculate(IIncidentContext context);
     }
 }

--- a/Assets/Scripts/Incidents/Contexts/ContextModifiers/IntegerContextModifierCalculator.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextModifiers/IntegerContextModifierCalculator.cs
@@ -9,5 +9,10 @@ namespace Game.Incidents
         {
             Operators = ExpressionHelpers.IntegerOperators;
         }
-    }
+
+		protected override int Clamp(int value)
+		{
+			return value < 0 ? 0 : value;
+		}
+	}
 }

--- a/Assets/Scripts/Incidents/Contexts/Faction.cs
+++ b/Assets/Scripts/Incidents/Contexts/Faction.cs
@@ -83,7 +83,7 @@ namespace Game.Incidents
 			}
 		}
 
-		public void Die()
+		override public void Die()
 		{
 			EventManager.Instance.RemoveEventHandler<RemoveContextEvent>(OnRemoveContextEvent);
 			EventManager.Instance.Dispatch(new RemoveContextEvent(this));

--- a/Assets/Scripts/Incidents/Contexts/Faction.cs
+++ b/Assets/Scripts/Incidents/Contexts/Faction.cs
@@ -21,6 +21,7 @@ namespace Game.Incidents
 		public Dictionary<IIncidentContext, int> FactionRelations { get; set; }
 		public int ControlledTiles => ControlledTileIndices.Count;
 		public List<City> Cities { get; set; }
+		public int NumCities => Cities.Count;
 		public int PoliticalPriority { get; set; }
 		public int EconomicPriority { get; set; }
 		public int ReligiousPriority { get; set; }

--- a/Assets/Scripts/Incidents/Contexts/Faction.cs
+++ b/Assets/Scripts/Incidents/Contexts/Faction.cs
@@ -14,7 +14,17 @@ namespace Game.Incidents
 	{
 		public Faction AffiliatedFaction => this;
 		public Type FactionType => ContextType;
-		public int Population { get; set; }
+		public int Population
+		{
+			get
+			{
+				return (int)populationFloat;
+			}
+			set
+			{
+				populationFloat = (float)value;
+			}
+		}
 		public int Influence { get; set; }
 		public int Wealth { get; set; }
 		public int MilitaryPower { get; set; }
@@ -37,6 +47,8 @@ namespace Game.Incidents
 		[HideInInspector]
 		public List<int> ControlledTileIndices { get; set; }
 
+		private float populationFloat;
+
 		public Faction() : base()
 		{
 			//need a smart generic way to go through our collections of contexts and remove a context
@@ -52,6 +64,7 @@ namespace Game.Incidents
 			FactionsAtWarWith = new List<IIncidentContext>();
 			CreateStartingCity();
 			CreateStartingGovernment();
+			populationFloat = 1000f;
 		}
 
 		public Faction(int population, int influence, int wealth, int politicalPriority, int economicPriority, int religiousPriority, int militaryPriority, int startingTiles = 1) : this(startingTiles)
@@ -186,7 +199,7 @@ namespace Game.Incidents
 
 		private void UpdateInfluence()
 		{
-			Influence += 1;
+			Influence += 3;
 		}
 
 		private void UpdateWealth()
@@ -199,7 +212,7 @@ namespace Game.Incidents
 
 		private void UpdatePopulation()
 		{
-
+			populationFloat *= 1.011f;
 		}
 
 		private void UpdatePERMS()

--- a/Assets/Scripts/Incidents/Contexts/IncidentContext.cs
+++ b/Assets/Scripts/Incidents/Contexts/IncidentContext.cs
@@ -45,6 +45,9 @@ namespace Game.Incidents
 		{
 
 		}
+
+		abstract public void Die();
+
 		public DataTable GetDataTable()
 		{
 			var table1 = new DataTable();

--- a/Assets/Scripts/Incidents/Contexts/IncidentContext.cs
+++ b/Assets/Scripts/Incidents/Contexts/IncidentContext.cs
@@ -75,7 +75,7 @@ namespace Game.Incidents
 
 		private void SetupHistoricalData()
 		{
-			propertyList = GetPropertyList();
+			propertyList = GetIntegerPropertyList();
 			historicalData = new Dictionary<string, List<YearData<int>>>();
 			//historicalData.Add("Influence", new List<IYearData>{ new YearData<int>(SimulationManager.Instance.world.Age, Influence) });
 			foreach (var property in propertyList)
@@ -89,7 +89,12 @@ namespace Game.Incidents
 			var propertyInfo = ContextType.GetProperties();
 			var interfacePropertyInfo = typeof(IIncidentContext).GetProperties();
 
-			return propertyInfo.Where(x => !interfacePropertyInfo.Any(y => x.Name == y.Name) && x.PropertyType == typeof(int)).ToList();
+			return propertyInfo.Where(x => !interfacePropertyInfo.Any(y => x.Name == y.Name)).ToList();
+		}
+
+		private List<PropertyInfo> GetIntegerPropertyList()
+		{
+			return GetPropertyList().Where(x => x.PropertyType == typeof(int)).ToList();
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/Contexts/InertIncidentContext.cs
+++ b/Assets/Scripts/Incidents/Contexts/InertIncidentContext.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Game.Simulation;
+using System;
 using System.Data;
 
 namespace Game.Incidents
@@ -25,6 +26,11 @@ namespace Game.Incidents
 		public void UpdateContext()
 		{
 
+		}
+
+		public void Die()
+		{
+			EventManager.Instance.Dispatch(new RemoveContextEvent(this));
 		}
 
 		public void UpdateHistoricalData()

--- a/Assets/Scripts/Incidents/Contexts/Inventory.cs
+++ b/Assets/Scripts/Incidents/Contexts/Inventory.cs
@@ -1,0 +1,21 @@
+﻿using Game.Generators.Items;
+using System;
+using System.Collections.Generic;
+
+namespace Game.Incidents
+{
+	public class Inventory : InertIncidentContext
+	{
+		public override Type ContextType => typeof(Inventory);
+		public List<Item> Items { get; set; }
+
+		public Inventory() 
+		{
+			Items = new List<Item>();
+		}
+		public Inventory(List<Item> items)
+		{
+			Items = items;
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/Contexts/Inventory.cs.meta
+++ b/Assets/Scripts/Incidents/Contexts/Inventory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92562c961efb1894a84f646fd8c8084c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Contexts/Landmark.cs
+++ b/Assets/Scripts/Incidents/Contexts/Landmark.cs
@@ -11,13 +11,13 @@ namespace Game.Incidents
 
 		public override Type ContextType => typeof(Landmark);
 
-		public List<Item> Inventory { get; set; }
+		public Inventory Inventory { get; set; }
 
 		public Landmark() { }
 		public Landmark(Location location)
 		{
 			CurrentLocation = location;
-			Inventory = new List<Item>();
+			Inventory = new Inventory();
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/Contexts/Person.cs
+++ b/Assets/Scripts/Incidents/Contexts/Person.cs
@@ -74,7 +74,7 @@ namespace Game.Incidents
 			OnDeathAction = action;
 		}
 
-		public void Die()
+		override public void Die()
 		{
 			SimulationManager.Instance.world.RemoveContext(this);
 			OnDeathAction?.Invoke();

--- a/Assets/Scripts/Incidents/Contexts/Person.cs
+++ b/Assets/Scripts/Incidents/Contexts/Person.cs
@@ -60,7 +60,7 @@ namespace Game.Incidents
 		override public void DeployContext()
 		{
 			IncidentService.Instance.PerformIncidents(this);
-			CheckForNaturalDeath();
+			CheckDestroyed();
 		}
 
 		override public void UpdateContext()
@@ -80,29 +80,15 @@ namespace Game.Incidents
 			OnDeathAction?.Invoke();
 		}
 
-		private void CheckForNaturalDeath()
+		private void CheckDestroyed()
 		{
 			var cuspA = Race.UpperAgeLimit * 0.3f;
 			var cuspB = Race.UpperAgeLimit * 0.85f;
 			var deathChance = -Mathf.Atan(((cuspA + (cuspB - cuspA)) - Age) / (Mathf.Sqrt(cuspB - cuspA) * Mathf.PI / 2.0f)) / Mathf.PI + 0.5f;
-			/*
-			if(Age <= cuspA)
-			{
-				deathChance = Mathf.Pow(Age / cuspA, 2) / 7.0f;
-			}
-			else if(Age > cuspA && Age <= cuspB)
-			{
-				deathChance = ((Age - cuspA) / ((cuspB - cuspA) / 4) - Mathf.Atan((cuspB - cuspA) / 2 - (Age - cuspA))) / 10 + 0.3f;
-			}
-			else
-			{
-				deathChance = Mathf.Sqrt(0.731025f * ((Age - cuspB) / Race.UpperAgeLimit * 0.75f) + 1);
-			}
-			*/
+
 			var randomValue = SimRandom.RandomFloat01();
 			if(randomValue <= deathChance)
 			{
-				//OutputLogger.Log(ID + " dying of natural causes.");
 				Die();
 			}			
 		}

--- a/Assets/Scripts/Incidents/Contexts/Person.cs
+++ b/Assets/Scripts/Incidents/Contexts/Person.cs
@@ -13,7 +13,7 @@ namespace Game.Incidents
 		public Person() { }
 		public Person(int age, Gender gender, Race race, Faction faction, int politicalPriority, int economicPriority,
 			int religiousPriority, int militaryPriority, int influence, int wealth, int strength, int dexterity,
-			int constitution, int intelligence, int wisdom, int charisma, List<Item> inventory = null, List<Person> parents = null)
+			int constitution, int intelligence, int wisdom, int charisma, Inventory inventory = null, List<Person> parents = null)
 		{
 			Age = age;
 			Race = race == null ? new Race() : race;
@@ -31,7 +31,7 @@ namespace Game.Incidents
 			Intelligence = intelligence;
 			Wisdom = wisdom;
 			Charisma = charisma;
-			Inventory = inventory == null ? new List<Item>() : inventory;
+			Inventory = inventory == null ? new Inventory() : inventory;
 			Parents = parents == null ? new List<Person>() : parents;
 		}
 
@@ -51,7 +51,7 @@ namespace Game.Incidents
 		public int Intelligence { get; set; }
 		public int Wisdom { get; set; }
 		public int Charisma { get; set; }
-		public List<Item> Inventory { get; set; }
+		public Inventory Inventory { get; set; }
 		public List<Person> Parents { get; set; }
 		public List<Person> Spouses { get; set; }
 		public List<Person> Children { get; set; }

--- a/Assets/Scripts/Incidents/Contexts/World.cs
+++ b/Assets/Scripts/Incidents/Contexts/World.cs
@@ -166,6 +166,8 @@ namespace Game.Simulation
 			IncidentService.Instance.PerformIncidents(this);
 		}
 
+		override public void Die() { }
+
 		private int GetNextID()
 		{
 			var next = nextID;

--- a/Assets/Scripts/Incidents/Contexts/World.cs
+++ b/Assets/Scripts/Incidents/Contexts/World.cs
@@ -36,10 +36,11 @@ namespace Game.Simulation
 
 		public World()
 		{
-			CurrentContexts = new TypeListDictionary<IIncidentContext>();
+			//CurrentContexts = new TypeListDictionary<IIncidentContext>();
+			EventManager.Instance.AddEventHandler<RemoveContextEvent>(OnRemoveContextEvent);
 		}
 
-		public World(HexGrid hexGrid)
+		public World(HexGrid hexGrid) : this()
 		{
 			this.hexGrid = hexGrid;
 			nextID = ID + 1;
@@ -113,6 +114,11 @@ namespace Game.Simulation
 		{
 			//Contexts[typeof(T)].Remove(context);
 			contextsToRemove[typeof(T)].Add(context);
+		}
+
+		private void OnRemoveContextEvent(RemoveContextEvent gameEvent)
+		{
+			RemoveContext(gameEvent.context);
 		}
 
 		private void DelayedAddContexts()

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/CriteriaEvaluator.cs
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/CriteriaEvaluator.cs
@@ -64,12 +64,7 @@ namespace Game.Incidents
 
         public T CombineExpressions(IIncidentContext context)
         {
-            var currentValue = expressions[0].GetValue(context);
-            for (int i = 0; i < expressions.Count - 1; i++)
-            {
-                currentValue = Operators[expressions[i].nextOperator].Invoke(currentValue, expressions[i + 1].GetValue(context));
-            }
-            return currentValue;
+            return Expression<T>.CombineExpressions(context, expressions, Operators);
         }
 
         private void AddNewExpression()

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/InventoryEvaluator.cs
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/InventoryEvaluator.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Game.Incidents
+{
+	public class InventoryEvaluator : ContextEvaluator<Inventory, IInventoryAffiliated>
+	{
+		public InventoryEvaluator() : base() { }
+		public InventoryEvaluator(string propertyName, Type contextType) : base(propertyName, contextType) { }
+
+		protected override Inventory GetContext(IIncidentContext context)
+		{
+			if ((typeof(IInventoryAffiliated)).IsAssignableFrom(context.ContextType))
+			{
+				return ((IInventoryAffiliated)context).Inventory;
+			}
+			else
+			{
+				return null;
+			}
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/InventoryEvaluator.cs.meta
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/InventoryEvaluator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 73277e0fae2198f4bb4aeac06ee8635c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Expression.cs
+++ b/Assets/Scripts/Incidents/Expression.cs
@@ -9,7 +9,7 @@ namespace Game.Incidents
 {
     public enum ExpressionType { Const, Method, Property, Range, Subexpression, From_Previous };
 
-
+    [HideReferenceObjectPicker]
 	public class Expression<T>
 	{
         private Dictionary<string, MethodInfo> methods;

--- a/Assets/Scripts/Incidents/IIncident.cs
+++ b/Assets/Scripts/Incidents/IIncident.cs
@@ -6,7 +6,7 @@ namespace Game.Incidents
 	{
 		string IncidentName { get; set; }
 		Type ContextType { get; }
-		int Weight { get; }
+		IIncidentWeight Weights { get; }
 		IncidentCriteriaContainer Criteria { get; }
 		IncidentActionHandlerContainer ActionContainer { get; }
 		bool PerformIncident(IIncidentContext context, ref IncidentReport report);

--- a/Assets/Scripts/Incidents/IIncidentContext.cs
+++ b/Assets/Scripts/Incidents/IIncidentContext.cs
@@ -11,6 +11,7 @@ namespace Game.Incidents
 		int ParentID { get; }
 		void UpdateContext();
 		void DeployContext();
+		void Die();
 		void UpdateHistoricalData();
 		DataTable GetDataTable();
 	}

--- a/Assets/Scripts/Incidents/IIncidentWeight.cs
+++ b/Assets/Scripts/Incidents/IIncidentWeight.cs
@@ -1,0 +1,7 @@
+﻿namespace Game.Incidents
+{
+	public interface IIncidentWeight 
+	{
+		int CalculateWeight(IIncidentContext context);
+	}
+}

--- a/Assets/Scripts/Incidents/IIncidentWeight.cs.meta
+++ b/Assets/Scripts/Incidents/IIncidentWeight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 731067aa3fdf84c408e9d5066f10472b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Incident.cs
+++ b/Assets/Scripts/Incidents/Incident.cs
@@ -9,27 +9,33 @@ namespace Game.Incidents
 	{
 		public string IncidentName { get; set; }
 		public Type ContextType { get; set; }
-		public int Weight { get; set; }
+		public IIncidentWeight Weights { get; set; }
 		public IncidentCriteriaContainer Criteria { get; set; }
 
 		public IncidentActionHandlerContainer ActionContainer { get; set; }
 
 		[JsonConstructor]
-		public Incident(Type contextType, IncidentCriteriaContainer criteria, IncidentActionHandlerContainer actions, int weight)
+		public Incident(Type contextType, IncidentCriteriaContainer criteria, IncidentActionHandlerContainer actions, IIncidentWeight weight)
 		{
 			ContextType = contextType;
 			Criteria = criteria;
 			ActionContainer = actions;
-			Weight = weight;
+			Weights = weight;
+			/*
+			var dataType = new Type[] { ContextType };
+			var genericBase = typeof(IncidentWeight<>);
+			var combinedType = genericBase.MakeGenericType(dataType);
+			Weights= (IIncidentWeight)Activator.CreateInstance(combinedType, weight);
+			*/
 		}
 
-		public Incident(string incidentName, Type contextType, List<IIncidentCriteria> criteria, IncidentActionHandlerContainer container, int weight = 5)
+		public Incident(string incidentName, Type contextType, List<IIncidentCriteria> criteria, IncidentActionHandlerContainer container, IIncidentWeight weight)
 		{
 			IncidentName = incidentName;
 			ContextType = contextType;
 			Criteria = new IncidentCriteriaContainer(criteria);
 			ActionContainer = container;
-			Weight = weight;
+			Weights = weight;
 		}
 
 		public bool PerformIncident(IIncidentContext context, ref IncidentReport report )

--- a/Assets/Scripts/Incidents/IncidentActionFieldCriteria.cs
+++ b/Assets/Scripts/Incidents/IncidentActionFieldCriteria.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Game.Generators.Items;
+using System;
 using System.Collections.Generic;
 
 namespace Game.Incidents
@@ -10,7 +11,7 @@ namespace Game.Incidents
 
 		protected override bool IsValidPropertyType(Type type)
 		{
-            return base.IsValidPropertyType(type) || type == typeof(Faction) || type == typeof(Location) || type == typeof(Type);
+            return base.IsValidPropertyType(type) || type == typeof(Faction) || type == typeof(Location) || type == typeof(Inventory) || type == typeof(Type);
         }
 
 		protected override void SetPrimitiveType()
@@ -24,6 +25,10 @@ namespace Game.Incidents
 			else if(PrimitiveType == typeof(Location))
 			{
 				evaluator = new LocationEvaluator(propertyName, ContextType);
+			}
+			else if(PrimitiveType == typeof(Inventory))
+			{
+				evaluator = new InventoryEvaluator(propertyName, ContextType);
 			}
 			else if(PrimitiveType == typeof(Type))
 			{

--- a/Assets/Scripts/Incidents/IncidentActions/ActionFields/ContextualIncidentActionField.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/ActionFields/ContextualIncidentActionField.cs
@@ -15,7 +15,7 @@ namespace Game.Incidents
 		[HideInInspector]
 		public Type parentType;
 
-		[OnValueChanged("RetrievalTypeChanged"), PropertyOrder(-1), ShowInInspector, ShowIf("ShowMethodChoice")]
+		[OnValueChanged("RetrievalTypeChanged"), PropertyOrder(-3), ShowInInspector, ShowIf("ShowMethodChoice")]
 		virtual public ActionFieldRetrievalMethod Method { get; set; }
 
 		[ShowInInspector, ShowIf("@this.ShowAllowSelf")]

--- a/Assets/Scripts/Incidents/IncidentActions/ActionFields/IncidentActionFieldContainer.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/ActionFields/IncidentActionFieldContainer.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 namespace Game.Incidents
 {
@@ -12,6 +13,9 @@ namespace Game.Incidents
 		public Type contextType;
 		[ShowIf("@this.actionField != null")]
 		public IIncidentActionField actionField;
+
+		[HideInInspector]
+		public Action onSetContextType;
 
 		private void SetContextType()
 		{
@@ -27,6 +31,8 @@ namespace Game.Incidents
 				actionField = (IIncidentActionField)Activator.CreateInstance(combinedType);
 			}
 			IncidentEditorWindow.UpdateActionFieldIDs();
+
+			onSetContextType.Invoke();
 		}
 		virtual protected IEnumerable<Type> GetFilteredTypeList()
 		{

--- a/Assets/Scripts/Incidents/IncidentActions/ActionFields/IncidentActionFieldContainer.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/ActionFields/IncidentActionFieldContainer.cs
@@ -15,10 +15,17 @@ namespace Game.Incidents
 
 		private void SetContextType()
 		{
-			var dataType = new Type[] { contextType };
-			var genericBase = typeof(ContextualIncidentActionField<>);
-			var combinedType = genericBase.MakeGenericType(dataType);
-			actionField = (IIncidentActionField)Activator.CreateInstance(combinedType);
+			if (contextType == typeof(Location))
+			{
+				actionField = new LocationActionField();
+			}
+			else
+			{
+				var dataType = new Type[] { contextType };
+				var genericBase = typeof(ContextualIncidentActionField<>);
+				var combinedType = genericBase.MakeGenericType(dataType);
+				actionField = (IIncidentActionField)Activator.CreateInstance(combinedType);
+			}
 			IncidentEditorWindow.UpdateActionFieldIDs();
 		}
 		virtual protected IEnumerable<Type> GetFilteredTypeList()

--- a/Assets/Scripts/Incidents/IncidentActions/ActionFields/IncidentActionFieldContainer.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/ActionFields/IncidentActionFieldContainer.cs
@@ -1,4 +1,5 @@
-﻿using Sirenix.OdinInspector;
+﻿using Newtonsoft.Json;
+using Sirenix.OdinInspector;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,7 +15,7 @@ namespace Game.Incidents
 		[ShowIf("@this.actionField != null")]
 		public IIncidentActionField actionField;
 
-		[HideInInspector]
+		[HideInInspector, JsonIgnore]
 		public Action onSetContextType;
 
 		private void SetContextType()
@@ -32,7 +33,7 @@ namespace Game.Incidents
 			}
 			IncidentEditorWindow.UpdateActionFieldIDs();
 
-			onSetContextType.Invoke();
+			onSetContextType?.Invoke();
 		}
 		virtual protected IEnumerable<Type> GetFilteredTypeList()
 		{

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeControlOfCityAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ChangeControlOfCityAction.cs
@@ -31,6 +31,7 @@
 				loser.ControlledTileIndices.Remove(tileIndex);
 			}
 
+			c.AffiliatedFaction = gainer;
 			//Might need to notify tile inhabitants later so they can adjust for the change
 		}
 	}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyCityAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyCityAction.cs
@@ -8,7 +8,7 @@ namespace Game.Incidents
 
 		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
 		{
-			SimulationManager.Instance.world.RemoveContext(city.GetTypedFieldValue());
+			city.GetTypedFieldValue().Die();
 			OutputLogger.Log("City destroyed!");
 		}
 	}

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyCityAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyCityAction.cs
@@ -4,7 +4,7 @@ namespace Game.Incidents
 {
 	public class DestroyCityAction : GenericIncidentAction
 	{
-		ContextualIncidentActionField<City> city;
+		public ContextualIncidentActionField<City> city;
 
 		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
 		{

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyFactionAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyFactionAction.cs
@@ -8,7 +8,7 @@ namespace Game.Incidents
 
 		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
 		{
-			EventManager.Instance.Dispatch(new RemoveContextEvent(faction.GetTypedFieldValue()));
+			faction.GetTypedFieldValue().Die();
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyFactionAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyFactionAction.cs
@@ -8,7 +8,7 @@ namespace Game.Incidents
 
 		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
 		{
-            SimulationManager.Instance.world.RemoveContext(faction.GetTypedFieldValue());
+			EventManager.Instance.Dispatch(new RemoveContextEvent(faction.GetTypedFieldValue()));
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyLandmarkAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/DestroyLandmarkAction.cs
@@ -8,7 +8,7 @@ namespace Game.Incidents
 
 		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
 		{
-			SimulationManager.Instance.world.RemoveContext(landmark.GetTypedFieldValue());
+			landmark.GetTypedFieldValue().Die();
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateItemAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/GetOrCreateItemAction.cs
@@ -9,13 +9,14 @@ namespace Game.Incidents
 {
 	public class GetOrCreateItemAction : GetOrCreateAction<Item>
 	{
+		public InterfacedIncidentActionFieldContainer<IInventoryAffiliated> inventoryToAddTo;
 		[ValueDropdown("GetFilteredTypeList"), ShowIf("@this.allowCreate")]
 		public Type itemType;
 
 		protected override Item MakeNew()
 		{
 			var newItem = (Item)Activator.CreateInstance(itemType);
-
+			((IInventoryAffiliated)inventoryToAddTo.actionField.GetFieldValue()).Inventory.Items.Add(newItem);
 			return newItem;
 		}
 

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/ModifyContextAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/ModifyContextAction.cs
@@ -10,7 +10,7 @@ namespace Game.Incidents
 	{
 		public ContextualIncidentActionField<T> contextToModify;
 
-        [ListDrawerSettings(CustomAddFunction = "AddNewModifier"), HorizontalGroup("Group 1"), HideReferenceObjectPicker]
+        [ListDrawerSettings(CustomAddFunction = "AddNewModifier", CustomRemoveIndexFunction = "RemoveModifier"), HorizontalGroup("Group 1"), HideReferenceObjectPicker]
         public List<ContextModifier<T>> modifiers;
 
         public ModifyContextAction() { }
@@ -24,6 +24,17 @@ namespace Game.Incidents
             OutputLogger.Log("Context Modified Via Action.");
 		}
 
+		public override void UpdateActionFieldIDs(ref int startingValue)
+		{
+			base.UpdateActionFieldIDs(ref startingValue);
+			foreach(var mod in modifiers)
+			{
+				mod.Calculator.ID = startingValue;
+				IncidentEditorWindow.calculators.Add(mod.Calculator);
+				startingValue++;
+			}
+		}
+
 		public override void UpdateEditor()
 		{
 			base.UpdateEditor();
@@ -33,6 +44,12 @@ namespace Game.Incidents
 		private void AddNewModifier()
 		{
             modifiers.Add(new ContextModifier<T>());
+		}
+
+		private void RemoveModifier(int index)
+		{
+			modifiers.RemoveAt(index);
+			IncidentEditorWindow.UpdateActionFieldIDs();
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/TradeAllItemsAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/TradeAllItemsAction.cs
@@ -1,22 +1,15 @@
-﻿using Game.Generators.Items;
-
-namespace Game.Incidents
+﻿namespace Game.Incidents
 {
-	public class TradeItemsAction : GenericIncidentAction
+	public class TradeAllItemsAction : GenericIncidentAction
 	{
-		public ContextualIncidentActionField<Item> itemField;
 		public InterfacedIncidentActionFieldContainer<IInventoryAffiliated> givingInventory;
 		public InterfacedIncidentActionFieldContainer<IInventoryAffiliated> receivingInventory;
 		public override void PerformAction(IIncidentContext context, ref IncidentReport report)
 		{
 			var giver = ((IInventoryAffiliated)givingInventory.actionField.GetFieldValue());
 			var receiver = ((IInventoryAffiliated)receivingInventory.actionField.GetFieldValue());
-			var item = itemField.GetTypedFieldValue();
-			if(giver.Inventory.Items.Contains(item))
-			{
-				giver.Inventory.Items.Remove(item);
-				receiver.Inventory.Items.Add(item);
-			}
+			receiver.Inventory.Items.AddRange(giver.Inventory.Items);
+			giver.Inventory.Items.Clear();
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/Actions/TradeAllItemsAction.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentActions/Actions/TradeAllItemsAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea33aca379385674d8d26f9588e7d9d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/BranchingAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/BranchingAction.cs
@@ -19,7 +19,7 @@ namespace Game.Incidents
 			{
 				if(!branch.VerifyActions(context))
 				{
-					OutputLogger.LogError(String.Format("{0} failed to verify.", GetType().Name));
+					OutputLogger.LogWarning(String.Format("{0} failed to verify branch {1}.", GetType().Name, branches.IndexOf(branch)));
 					return false;
 				}
 			}

--- a/Assets/Scripts/Incidents/IncidentActions/BranchingAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/BranchingAction.cs
@@ -32,12 +32,12 @@ namespace Game.Incidents
 			var totalWeight = 0;
 			foreach (var branch in branches)
 			{
-				totalWeight += branch.GetWeight(context);
+				totalWeight += branch.weightModifier.Calculate();
 			}
 			var decider = SimRandom.RandomRange(0, totalWeight);
 			for(int i = 0; i < branches.Count; i++)
 			{
-				totalWeight -= branches[i].GetWeight(context);
+				totalWeight -= branches[i].weightModifier.Calculate();
 				if(decider > totalWeight)
 				{
 					branches[i].PerformActions(context, ref report);

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
@@ -228,7 +228,14 @@ namespace Game.Incidents
 
 			foreach(var type in types)
 			{
-				actionFields.AddRange(fields.Where(x => x.FieldType.IsGenericType && x.FieldType.GetGenericTypeDefinition() == type));
+				if (type.IsGenericType)
+				{
+					actionFields.AddRange(fields.Where(x => x.FieldType.IsGenericType && x.FieldType.GetGenericTypeDefinition() == type));
+				}
+				else
+				{
+					actionFields.AddRange(fields.Where(x => x.FieldType == type));
+				}
 			}
 
 			return actionFields;

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentAction.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Game.Simulation;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,7 +20,7 @@ namespace Game.Incidents
 				var af = field.GetValue(this) as IIncidentActionField;
 				if (!af.CalculateField(context))
 				{
-					OutputLogger.Log(String.Format("{0} failed to verify.", GetType().Name));
+					OutputLogger.LogWarning(String.Format("{0} failed to verify in year {1} for incident: {2}.", GetType().Name, SimulationManager.Instance.world.Age, IncidentService.Instance.CurrentIncident.IncidentName));
 					return false;
 				}
 			}

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentActionBranch.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentActionBranch.cs
@@ -24,7 +24,7 @@ namespace Game.Incidents
 
 		public bool VerifyActions(IIncidentContext context)
 		{
-			return actionHandler.VerifyActions(context) && weightModifier.container.actionField.CalculateField(context);
+			return actionHandler.VerifyActions(context) && weightModifier.VerifyField(context);
 		}
 
 		public void PerformActions(IIncidentContext context, ref IncidentReport report)

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentActionBranch.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentActionBranch.cs
@@ -8,9 +8,8 @@ namespace Game.Incidents
 	{
 		public Type ContextType { get; set; }
 
-		public int baseWeight;
-		[ListDrawerSettings(CustomAddFunction = "AddModifier"), HideReferenceObjectPicker]
-		public List<IncidentActionBranchWeightModifier> modifiers;
+		[HideReferenceObjectPicker]
+		public IncidentActionBranchWeightModifier weightModifier;
 
 		[HideReferenceObjectPicker]
 		public IncidentActionHandlerContainer actionHandler;
@@ -19,23 +18,13 @@ namespace Game.Incidents
 		public IncidentActionBranch(Type type)
 		{
 			ContextType = type;
-			modifiers = new List<IncidentActionBranchWeightModifier>();
+			weightModifier = new IncidentActionBranchWeightModifier(type);
 			actionHandler = new IncidentActionHandlerContainer(type);
-		}
-
-		public int GetWeight(IIncidentContext context)
-		{
-			var totalWeight = baseWeight;
-			foreach(var mod in modifiers)
-			{
-				totalWeight += mod.Evaluate(context);
-			}
-			return totalWeight;
 		}
 
 		public bool VerifyActions(IIncidentContext context)
 		{
-			return actionHandler.VerifyActions(context);
+			return actionHandler.VerifyActions(context) && weightModifier.container.actionField.CalculateField(context);
 		}
 
 		public void PerformActions(IIncidentContext context, ref IncidentReport report)
@@ -56,11 +45,6 @@ namespace Game.Incidents
 		public IIncidentActionField GetContextField(int id)
 		{
 			return actionHandler.GetContextFromActionFields(id);
-		}
-
-		private void AddModifier()
-		{
-			modifiers.Add(new IncidentActionBranchWeightModifier(ContextType));
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentActionBranchWeightModifier.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentActionBranchWeightModifier.cs
@@ -7,6 +7,7 @@ namespace Game.Incidents
 {
 	public class IncidentActionBranchWeightModifier
 	{
+		[OnValueChanged("ToggleAdvancedMode")]
 		public bool advancedMode;
 		[ShowIf("@this.advancedMode == false")]
 		public int baseWeight;
@@ -41,6 +42,15 @@ namespace Game.Incidents
 		public int Calculate()
 		{
 			return advancedMode ? weight.CalculateWeight(container.actionField.GetFieldValue()) : baseWeight;
+		}
+
+		private void ToggleAdvancedMode()
+		{
+			if(advancedMode && container == null)
+			{
+				container = new IncidentActionFieldContainer();
+				container.onSetContextType += Setup;
+			}
 		}
 
 		private void Setup()

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentActionBranchWeightModifier.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentActionBranchWeightModifier.cs
@@ -53,9 +53,5 @@ namespace Game.Incidents
 			var combinedType = genericBase.MakeGenericType(dataType);
 			weight = (IIncidentWeight)Activator.CreateInstance(combinedType);
 		}
-
-		//Step 1: Have a ContextualIncidentActionField where we can first choose the context type (like in the get contexts action)
-		//Step 2: Once we know the type, use it to create an IncidentModifier<T>
-		//Step 3: As part of the branch weighting, we first grab the context from the action field and pass that into the modifiers calculator
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentActionBranchWeightModifier.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentActionBranchWeightModifier.cs
@@ -16,20 +16,12 @@ namespace Game.Incidents
 		[ShowIf("ShowWeight"), HideReferenceObjectPicker]
 		public IIncidentWeight weight;
 		private bool ShowWeight => advancedMode && weight != null;
-		public IncidentActionBranchWeightModifier() { }
+		public IncidentActionBranchWeightModifier()
+		{
+			
+		}
 		public IncidentActionBranchWeightModifier(Type contextType)
 		{
-			/*
-			var dataType = new Type[] { contextType };
-			var genericBase = typeof(IncidentWeight<>);
-			var combinedType = genericBase.MakeGenericType(dataType);
-			weight = (IIncidentWeight)Activator.CreateInstance(combinedType);
-
-			genericBase = typeof(ContextualIncidentActionField<>);
-			combinedType = genericBase.MakeGenericType(dataType);
-			actionField = (IIncidentActionField)Activator.CreateInstance(combinedType);
-			*/
-
 			container = new IncidentActionFieldContainer();
 			container.onSetContextType += Setup;
 		}
@@ -49,8 +41,9 @@ namespace Game.Incidents
 			if(advancedMode && container == null)
 			{
 				container = new IncidentActionFieldContainer();
-				container.onSetContextType += Setup;
 			}
+
+			container.onSetContextType += Setup;
 		}
 
 		private void Setup()

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentActionHandlerContainer.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentActionHandlerContainer.cs
@@ -111,8 +111,6 @@ namespace Game.Incidents
 			return null;
 		}
 
-		//Need a way to go get all ModifyContextActions and get all of their ContextModifiers to check IDs against their calculators
-
 		private void AddNewActionContainer()
 		{
 			Actions.Add(new IncidentActionHandler());

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentActionHandlerContainer.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentActionHandlerContainer.cs
@@ -111,6 +111,8 @@ namespace Game.Incidents
 			return null;
 		}
 
+		//Need a way to go get all ModifyContextActions and get all of their ContextModifiers to check IDs against their calculators
+
 		private void AddNewActionContainer()
 		{
 			Actions.Add(new IncidentActionHandler());

--- a/Assets/Scripts/Incidents/IncidentCriteria.cs
+++ b/Assets/Scripts/Incidents/IncidentCriteria.cs
@@ -68,6 +68,7 @@ namespace Game.Incidents
                 || type == typeof(Dictionary<IIncidentContext, float>)
                 || type == typeof(Dictionary<IIncidentContext, bool>)
                 || type == typeof(List<IIncidentContext>);
+                //|| (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>) && typeof(IIncidentContext).IsAssignableFrom(type.GetGenericArguments()[0]));
 		}
 
         private IEnumerable<string> GetPropertyNames()

--- a/Assets/Scripts/Incidents/IncidentEditorWindow.cs
+++ b/Assets/Scripts/Incidents/IncidentEditorWindow.cs
@@ -96,7 +96,7 @@ namespace Game.Incidents
         [Button("Save"), ShowIfGroup("ContextTypeChosen"), PropertyOrder(10)]
         public void OnSaveButtonPressed()
 		{
-            if (ContextTypeChosen && actionHandler.Actions.Count > 0)
+            if (ContextTypeChosen)// && actionHandler.Actions.Count > 0)
             {
                 var incident = new Incident(incidentName, ContextType, criteria, actionHandler, weight);
 

--- a/Assets/Scripts/Incidents/IncidentEditorWindow.cs
+++ b/Assets/Scripts/Incidents/IncidentEditorWindow.cs
@@ -117,31 +117,7 @@ namespace Game.Incidents
             UpdateMainContextActionFieldIDs(ref numActionFields);
             actionHandler.UpdateActionFieldIDs(ref numActionFields);
 		}
-/*
-		public static void UpdateExpressionIDs(IContextModifierCalculator calculator, bool add)
-		{
-            int id = 0;
-            if(calculators == null)
-			{
-                calculators = new List<IContextModifierCalculator>();
-			}
 
-            if(add && !calculators.Contains(calculator))
-			{
-                calculators.Add(calculator);
-			}
-            if(!add && calculators.Contains(calculator))
-			{
-                calculators.Remove(calculator);
-			}
-
-            foreach(var c in calculators)
-			{
-                c.ID = id;
-                id++;
-			}
-		}
-*/
 		private static void UpdateMainContextActionFieldIDs(ref int startingValue)
 		{
             if (startingValue == 0)

--- a/Assets/Scripts/Incidents/IncidentEditorWindow.cs
+++ b/Assets/Scripts/Incidents/IncidentEditorWindow.cs
@@ -53,8 +53,8 @@ namespace Game.Incidents
         [ShowIfGroup("ContextTypeChosen")]
         public string incidentName;
 
-        [Range(0, 20), ShowIfGroup("ContextTypeChosen")]
-        public int weight;
+        [ShowIfGroup("ContextTypeChosen"), HideReferenceObjectPicker]
+        public IIncidentWeight weight;
 
         [ShowIfGroup("ContextTypeChosen"), ListDrawerSettings(CustomAddFunction = "AddNewCriteriaItem"), HideReferenceObjectPicker]
         public List<IIncidentCriteria> criteria;
@@ -67,7 +67,7 @@ namespace Game.Incidents
         {
             incidentContextType = null;
             incidentName = string.Empty;
-            weight = 0;
+            weight = null;
             modeChosen = true;
         }
 
@@ -81,7 +81,7 @@ namespace Game.Incidents
             incidentContextType = loadedIncident.ContextType;
             ContextType = incidentContextType;
             incidentName = savedIncidentName;
-            weight = loadedIncident.Weight;
+            weight = loadedIncident.Weights;
             criteria = loadedIncident.Criteria.criteria;
             actionHandler = loadedIncident.ActionContainer;
             UpdateActionFieldIDs();
@@ -183,12 +183,21 @@ namespace Game.Incidents
             return files;
 		}
 
-        void SetContextType()
+        private void SetContextType()
 		{
             ContextType = incidentContextType;
             criteria = new List<IIncidentCriteria>();
             actionHandler = new IncidentActionHandlerContainer(ContextType);
+            CreateIncidentWeight();
 		}
+
+        private void CreateIncidentWeight()
+		{
+            var dataType = new Type[] { incidentContextType };
+            var genericBase = typeof(IncidentWeight<>);
+            var combinedType = genericBase.MakeGenericType(dataType);
+            weight = (IIncidentWeight)Activator.CreateInstance(combinedType);
+        }
 
         private void AddNewCriteriaItem()
         {

--- a/Assets/Scripts/Incidents/IncidentEditorWindow.cs
+++ b/Assets/Scripts/Incidents/IncidentEditorWindow.cs
@@ -33,10 +33,11 @@ namespace Game.Incidents
         public static Type ContextType
 		{
             get { return contextType; }
-            set {
-                    contextType = value;
-                    GetPropertyList();
-                }
+            set 
+            {
+                contextType = value;
+                GetPropertyList();
+            }
 		}
 
         static private int numActionFields;
@@ -44,6 +45,7 @@ namespace Game.Incidents
 
         public static Dictionary<string, Type> Properties => properties;
         public static List<IIncidentActionField> actionFields = new List<IIncidentActionField>();
+        public static List<IContextModifierCalculator> calculators = new List<IContextModifierCalculator>();
 
 		[ShowIf("@this.modeChosen == true"), ValueDropdown("GetFilteredTypeList"), OnValueChanged("SetContextType"), LabelText("Incident Type"), PropertySpace(SpaceBefore = 30, SpaceAfter = 20)]
         public Type incidentContextType;
@@ -110,12 +112,37 @@ namespace Game.Incidents
         public static void UpdateActionFieldIDs()
 		{
             actionFields.Clear();
+            calculators.Clear();
             numActionFields = 0;
             UpdateMainContextActionFieldIDs(ref numActionFields);
             actionHandler.UpdateActionFieldIDs(ref numActionFields);
 		}
+/*
+		public static void UpdateExpressionIDs(IContextModifierCalculator calculator, bool add)
+		{
+            int id = 0;
+            if(calculators == null)
+			{
+                calculators = new List<IContextModifierCalculator>();
+			}
 
-        private static void UpdateMainContextActionFieldIDs(ref int startingValue)
+            if(add && !calculators.Contains(calculator))
+			{
+                calculators.Add(calculator);
+			}
+            if(!add && calculators.Contains(calculator))
+			{
+                calculators.Remove(calculator);
+			}
+
+            foreach(var c in calculators)
+			{
+                c.ID = id;
+                id++;
+			}
+		}
+*/
+		private static void UpdateMainContextActionFieldIDs(ref int startingValue)
 		{
             if (startingValue == 0)
             {

--- a/Assets/Scripts/Incidents/IncidentService.cs
+++ b/Assets/Scripts/Incidents/IncidentService.cs
@@ -109,11 +109,12 @@ namespace Game.Incidents
 			Dictionary<int, List<IIncident>> sortedItems = new Dictionary<int, List<IIncident>>();
 			foreach(var item in items)
 			{
-				if(!sortedItems.ContainsKey(item.Weight))
+				var weight = item.Weights.CalculateWeight(context);
+				if(!sortedItems.ContainsKey(weight))
 				{
-					sortedItems.Add(item.Weight, new List<IIncident>());
+					sortedItems.Add(weight, new List<IIncident>());
 				}
-				sortedItems[item.Weight].Add(item);
+				sortedItems[weight].Add(item);
 			}
 			return sortedItems;
 		}

--- a/Assets/Scripts/Incidents/IncidentService.cs
+++ b/Assets/Scripts/Incidents/IncidentService.cs
@@ -12,6 +12,8 @@ namespace Game.Incidents
 	{
 		private static IncidentService instance;
 
+		public Dictionary<string, ExpressionValue> currentExpressionValues;
+
 		private List<IIncident> incidents;
 		private List<DelayedIncidentContext> delayedContexts;
 		private int nextIncidentID;
@@ -67,6 +69,7 @@ namespace Game.Incidents
 					CurrentIncident = SimRandom.RandomEntryFromWeightedDictionary(possibleIncidents);
 					OutputLogger.Log("Attempting to run incident: " + CurrentIncident.IncidentName);
 					completed = CurrentIncident.PerformIncident(incidentContext, ref report);
+					currentExpressionValues.Clear();
 				}
 
 				if (completed)
@@ -132,6 +135,8 @@ namespace Game.Incidents
 			nextIncidentID = 0;
 			delayedContexts = new List<DelayedIncidentContext>();
 			reports = new List<IncidentReport>();
+
+			currentExpressionValues = new Dictionary<string, ExpressionValue>();
 		}
 	}
 }

--- a/Assets/Scripts/Incidents/IncidentWeight.cs
+++ b/Assets/Scripts/Incidents/IncidentWeight.cs
@@ -45,6 +45,11 @@ namespace Game.Incidents
 		private void AddNewExpression()
 		{
 			expressions.Add(new Expression<int>(typeof(T)));
+			for (int i = 0; i < expressions.Count - 1; i++)
+			{
+				expressions[i].hasNextOperator = true;
+			}
+			expressions[expressions.Count - 1].hasNextOperator = false;
 		}
 
 		private List<string> GetOperatorNames()

--- a/Assets/Scripts/Incidents/IncidentWeight.cs
+++ b/Assets/Scripts/Incidents/IncidentWeight.cs
@@ -1,0 +1,55 @@
+﻿using Sirenix.OdinInspector;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Game.Incidents
+{
+	public class IncidentWeight<T> : IIncidentWeight where T : IIncidentContext
+	{
+		[Range(0, 20)]
+		public int baseWeight;
+
+		[ValueDropdown("GetOperatorNames"), HorizontalGroup("Group 1", 50), HideLabel]
+		public string Operation;
+
+		[ListDrawerSettings(CustomAddFunction = "AddNewExpression"), HideReferenceObjectPicker]
+		public List<Expression<int>> expressions;
+
+		protected Dictionary<string, Func<int, int, int>> Operators { get; set; }
+
+		public IncidentWeight()
+		{
+			Operators = ExpressionHelpers.IntegerOperators;
+			expressions = new List<Expression<int>>();
+		}
+
+		public IncidentWeight(int baseWeight) : this()
+		{
+			this.baseWeight = baseWeight;
+		}
+
+		public int CalculateWeight(IIncidentContext context)
+		{
+			if (expressions.Count > 0 && context != null)
+			{
+				return Operators[Operation].Invoke(baseWeight, Expression<int>.CombineExpressions(context, expressions, Operators));
+			}
+			else
+			{
+				return baseWeight;
+			}
+		}
+
+		private void AddNewExpression()
+		{
+			expressions.Add(new Expression<int>(typeof(T)));
+		}
+
+		private List<string> GetOperatorNames()
+		{
+			return Operators.Keys.ToList();
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/IncidentWeight.cs.meta
+++ b/Assets/Scripts/Incidents/IncidentWeight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27df0b4920caa1b46a32c7726d346b53
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Simulation/EventManagement.meta
+++ b/Assets/Scripts/Simulation/EventManagement.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 57711dde3b2559b4bb2496e0c534bff1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Simulation/EventManagement/EventManager.cs
+++ b/Assets/Scripts/Simulation/EventManagement/EventManager.cs
@@ -1,0 +1,160 @@
+﻿
+using Game.Incidents;
+using System;
+using System.Collections.Generic;
+
+namespace Game.Simulation
+{
+    public class EventManager
+    {
+        private static EventManager instance;
+        public static EventManager Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new EventManager();
+                }
+                return instance;
+            }
+        }
+
+        private Dictionary<Type, List<ISimulationEventHandler>> handlers = new Dictionary<Type, List<ISimulationEventHandler>>();
+
+        public void Clear()
+        {
+            handlers.Clear();
+        }
+
+        public void Dispatch(ISimulationEvent simEvent)
+        {
+            List<ISimulationEventHandler> handlerList;
+
+            if (handlers.TryGetValue(simEvent.GetType(), out handlerList))
+            {
+                for (int index = 0, maxIndex = handlerList.Count; index < maxIndex; index++)
+                {
+                    if (handlerList[index] != null)
+                    {
+                        handlerList[index].Invoke(simEvent);
+                    }
+                }
+            }
+        }
+
+        public void AddEventHandler(Type eventType, Action handler)
+        {
+            var specialAction = new SimulationEventHandler();
+            specialAction.Handler = handler;
+
+            RegisterAction(eventType, specialAction);
+        }
+
+        public void AddEventHandler(Type eventType, Action<ISimulationEvent> handler)
+        {
+            var specialAction = new SimulationEventHandler<ISimulationEvent>();
+            specialAction.Handler = handler;
+
+            RegisterAction(eventType, specialAction);
+        }
+
+        public void AddEventHandler<T>(Action handler) where T : ISimulationEvent
+        {
+            AddEventHandler(typeof(T), handler);
+        }
+
+        public void AddEventHandler<T>(Action<T> handler) where T : ISimulationEvent
+        {
+            var specialAction = new SimulationEventHandler<T>();
+            specialAction.Handler = handler;
+
+            RegisterAction(typeof(T), specialAction);
+        }
+
+        public List<ISimulationEventHandler> RemoveEventHandler(Type eventType, object handler)
+        {
+            List<ISimulationEventHandler> handlerList;
+
+            if (handlers.TryGetValue(eventType, out handlerList))
+            {
+                var index = handlerList.FindIndex(i => (i != null) && i.Target.Equals(handler));
+                if (index >= 0)
+                {
+                    handlerList.RemoveAt(index);
+                }
+                else
+                {
+                    handlerList = null;
+                }
+            }
+
+            return handlerList;
+        }
+
+		public void RemoveEventHandler<T>(Action<T> handler)
+		{
+            RemoveEventHandler(typeof(T), handler);
+        }
+
+		public List<ISimulationEventHandler> RemoveEventHandler<T>(object handler) where T : ISimulationEvent
+		{
+            return RemoveEventHandler(typeof(T), handler);
+		}
+
+        private void RegisterAction(Type eventType, ISimulationEventHandler action)
+        {
+            if (!handlers.ContainsKey(eventType))
+            {
+                handlers.Add(eventType, new List<ISimulationEventHandler>());
+            }
+
+            var handlerList = handlers[eventType];
+
+            handlerList.Add(action);
+        }
+    }
+
+    public interface ISimulationEventHandler
+	{
+		object Target { get; }
+        void Invoke(ISimulationEvent simulationEvent);
+	}
+
+    public class SimulationEventHandler : ISimulationEventHandler
+	{
+        public object Target { get { return Handler; } }
+        public Action Handler { get; set; }
+
+        public void Invoke(ISimulationEvent simEvent)
+        {
+            Handler.Invoke();
+        }
+    }
+
+    public class SimulationEventHandler<T> : ISimulationEventHandler where T : ISimulationEvent
+    {
+        public object Target { get { return Handler; } }
+        public Action<T> Handler { get; set; }
+
+        public void Invoke(ISimulationEvent simEvent)
+        {
+            Handler.Invoke((T)simEvent);
+        }
+    }
+
+    public interface ISimulationEvent
+	{
+
+	}
+
+    public class RemoveContextEvent : ISimulationEvent
+	{
+        public IIncidentContext context;
+
+		public RemoveContextEvent(IIncidentContext context)
+		{
+			this.context = context;
+		}
+	}
+}

--- a/Assets/Scripts/Simulation/EventManagement/EventManager.cs.meta
+++ b/Assets/Scripts/Simulation/EventManagement/EventManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a77721e101f47041a4305dbee300fcb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Simulation/SimulationUtilities.cs
+++ b/Assets/Scripts/Simulation/SimulationUtilities.cs
@@ -123,7 +123,7 @@ namespace Game.Simulation
 				for (HexDirection d = HexDirection.NE; d <= HexDirection.NW; d++)
 				{
 					HexCell neighbor = hexCell.GetNeighbor(d);
-					if (!controlledCells.Contains(neighbor.Index))
+					if (neighbor != null && !controlledCells.Contains(neighbor.Index))
 					{
 						possibleIndices.Add(hexCell.Index);
 						break;
@@ -163,7 +163,7 @@ namespace Game.Simulation
 				for (HexDirection d = HexDirection.NE; d <= HexDirection.NW; d++)
 				{
 					HexCell neighbor = hexCell.GetNeighbor(d);
-					if (!controlledCells.Contains(neighbor.Index))
+					if (neighbor != null && !controlledCells.Contains(neighbor.Index))
 					{
 						possibleIndices.Add(neighbor.Index);
 					}

--- a/Assets/Scripts/Simulation/SimulationUtilities.cs
+++ b/Assets/Scripts/Simulation/SimulationUtilities.cs
@@ -111,5 +111,109 @@ namespace Game.Simulation
 
 			return claimedList;
 		}
+
+		public static List<int> FindBorderWithinFaction(Faction faction)
+		{
+			List<int> possibleIndices = new List<int>();
+			var controlledCells = faction.ControlledTileIndices;
+
+			foreach (var cell in controlledCells)
+			{
+				HexCell hexCell = SimulationManager.Instance.HexGrid.GetCell(cell);
+				for (HexDirection d = HexDirection.NE; d <= HexDirection.NW; d++)
+				{
+					HexCell neighbor = hexCell.GetNeighbor(d);
+					if (!controlledCells.Contains(neighbor.Index))
+					{
+						possibleIndices.Add(hexCell.Index);
+						break;
+					}
+				}
+			}
+
+			return possibleIndices;
+		}
+
+		public static List<int> FindCitylessBorderWithinFaction(Faction faction)
+		{
+			var cityTiles = GetCellsWithCities();
+			var borderTiles = FindBorderWithinFaction(faction);
+			List<int> possibleIndices = new List<int>();
+
+			foreach (var cell in borderTiles)
+			{
+				if (!cityTiles.Contains(cell))
+				{
+					possibleIndices.Add(cell);
+				}
+			}
+
+			return possibleIndices;
+		}
+
+		public static List<int> FindBorderOutsideFaction(Faction faction)
+		{
+			var insideIndices = FindBorderWithinFaction(faction);
+			var possibleIndices = new HashSet<int>();
+			var controlledCells = faction.ControlledTileIndices;
+
+			foreach (var cell in insideIndices)
+			{
+				HexCell hexCell = SimulationManager.Instance.HexGrid.GetCell(cell);
+				for (HexDirection d = HexDirection.NE; d <= HexDirection.NW; d++)
+				{
+					HexCell neighbor = hexCell.GetNeighbor(d);
+					if (!controlledCells.Contains(neighbor.Index))
+					{
+						possibleIndices.Add(neighbor.Index);
+					}
+				}
+			}
+
+			return new List<int>(possibleIndices);
+		}
+
+		public static List<int> FindSharedBorderFaction(Faction faction)
+		{
+			var outsideIndices = FindBorderOutsideFaction(faction);
+			var possibleIndices = new List<int>();
+			var claimedCells = GetClaimedCells();
+
+			foreach (var cell in outsideIndices)
+			{
+				if (claimedCells.Contains(cell))
+				{
+					possibleIndices.Add(cell);
+				}
+			}
+
+			return possibleIndices;
+		}
+
+		public static List<int> FindCitylessCellWithinFaction(Faction faction, int minDistanceFromCities)
+		{
+			List<int> possibleIndices = new List<int>();
+			var cityTiles = GetCellsWithCities();
+			foreach (var index in faction.ControlledTileIndices)
+			{
+				var cell = SimulationManager.Instance.HexGrid.cells[index];
+				var valid = true;
+				foreach (var cityIndex in cityTiles)
+				{
+					var cityCell = SimulationManager.Instance.HexGrid.cells[cityIndex];
+					if (cell.coordinates.DistanceTo(cityCell.coordinates) < minDistanceFromCities)
+					{
+						valid = false;
+						break;
+					}
+				}
+				if (valid)
+				{
+					possibleIndices.Add(index);
+				}
+			}
+
+			return possibleIndices;
+		}
 	}
 }

--- a/Assets/Scripts/Visuals/World/HexMap/Scripts/UI/SaveUtilities.cs
+++ b/Assets/Scripts/Visuals/World/HexMap/Scripts/UI/SaveUtilities.cs
@@ -14,7 +14,8 @@ namespace Game.IO
 		{
 			// ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
 			PreserveReferencesHandling = PreserveReferencesHandling.Objects,
-			TypeNameHandling = TypeNameHandling.All
+			TypeNameHandling = TypeNameHandling.All,
+			MissingMemberHandling = MissingMemberHandling.Ignore
 		};
 
 		public static string ROOT = Path.Combine(Application.persistentDataPath, "GameData");


### PR DESCRIPTION
The goal of this ticket was to run through the creation of 3 fairly simple incidents that would simulate different types of battle, hoping that I would be able to find a few holes in the Incident Service where I had forgotten to cover a specific use case. And find them I did! Here's a list of the improvements made in order to make creating more complex incidents possible:
- Added subexpressions to `Expression` to allow them to simulate parens by doing those operations first by themselves. This was mostly to handle the case where I need to divide an integer before multiplying it because rounding and all that.
- Added the `EventManager` back to handle situations where we want to broadcast something that happened to multiple unconnected objects, such as when a context is removed from the world.
- Added the ability for `Expressions` to pull values from previously calculated expressions, to cover cases where we want to use the same value but couldn't calculate it again due to RNG involvement or some other reason.
- Added multiple more ways to find `Locations` including finding them based on `Faction` borders.
- Added a new weighting system that uses expressions to dynamically determine weights both for action branches and for the `Incident` as a whole.
- Turned `Inventory` into it's own `IIncidentContext` so that I could use an `InventoryEvaluator` to find and compare them.

And with all of these improvements, the 3 battle scenarios I currently have are:
- Battle over a hex
- Battle over an item of importance
- City siege