### PR TITLE
02-04-2022 Bugfixes for Incidents

### DIFF
--- a/Assets/Resources/IncidentData/Person_Murder_00.json
+++ b/Assets/Resources/IncidentData/Person_Murder_00.json
@@ -26,7 +26,7 @@
             "min": 0,
             "max": 20,
             "constant": 0,
-            "Value": 15,
+            "Value": 18,
             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
           },
           "subexpressions": null,
@@ -50,7 +50,7 @@
             "min": 0,
             "max": 20,
             "constant": 0,
-            "Value": 1,
+            "Value": 14,
             "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
           },
           "subexpressions": null,
@@ -95,11 +95,52 @@
                 "AllowNull": false,
                 "criteria": {
                   "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
-                  "$values": []
+                  "$values": [
+                    {
+                      "$id": "13",
+                      "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                      "propertyName": "AffiliatedFaction",
+                      "evaluator": {
+                        "$id": "14",
+                        "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
+                        "compareTo": {
+                          "$id": "15",
+                          "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                          "contextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                          "actionField": {
+                            "$id": "16",
+                            "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+                            "parentType": null,
+                            "AllowSelf": false,
+                            "AllowNull": false,
+                            "criteria": {
+                              "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                              "$values": []
+                            },
+                            "value": null,
+                            "delayedValue": null,
+                            "Method": 1,
+                            "PreviousField": "{0} - Original Context",
+                            "PreviousFieldID": 0,
+                            "ActionFieldID": -1,
+                            "NameID": null,
+                            "ActionFieldIDString": "{-1}",
+                            "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                          }
+                        },
+                        "propertyName": "AffiliatedFaction",
+                        "Comparator": "==",
+                        "Type": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                        "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                      },
+                      "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                      "PrimitiveType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    }
+                  ]
                 },
                 "value": null,
                 "delayedValue": null,
-                "Method": 1,
+                "Method": 0,
                 "PreviousField": "{0} - Original Context",
                 "PreviousFieldID": 0,
                 "ActionFieldID": 1,
@@ -107,6 +148,454 @@
                 "ActionFieldIDString": "{1}",
                 "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
               }
+            }
+          }
+        },
+        {
+          "$id": "17",
+          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+          "incidentAction": {
+            "$id": "18",
+            "$type": "Game.Incidents.BranchingAction, Assembly-CSharp",
+            "branches": {
+              "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionBranch, Assembly-CSharp]], mscorlib",
+              "$values": [
+                {
+                  "$id": "19",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "20",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 1,
+                    "container": {
+                      "$id": "21",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": null,
+                      "actionField": null
+                    },
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "22",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "It is thought to be the work of an assassin commonly in the employ of {0}",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "23",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "24",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 1,
+                    "container": {
+                      "$id": "25",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": null,
+                      "actionField": null
+                    },
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "26",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "Rumor spreads that {0} was involved somehow.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "27",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "28",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 1,
+                    "container": {
+                      "$id": "29",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": null,
+                      "actionField": null
+                    },
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "30",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "There was pervasive rumors that {5} ordered their death.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": [
+                        {
+                          "$id": "31",
+                          "$type": "Game.Incidents.IncidentActionHandler, Assembly-CSharp",
+                          "incidentAction": {
+                            "$id": "32",
+                            "$type": "Game.Incidents.GetOrCreatePersonAction, Assembly-CSharp",
+                            "parent": {
+                              "$id": "33",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 0,
+                              "PreviousField": null,
+                              "PreviousFieldID": -1,
+                              "ActionFieldID": 2,
+                              "NameID": "{2}:GetOrCreatePersonAction:parent",
+                              "ActionFieldIDString": "{2}",
+                              "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "race": {
+                              "$id": "34",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Race, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 0,
+                              "PreviousField": null,
+                              "PreviousFieldID": -1,
+                              "ActionFieldID": 3,
+                              "NameID": "{3}:GetOrCreatePersonAction:race",
+                              "ActionFieldIDString": "{3}",
+                              "ContextType": "Game.Incidents.Race, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "faction": {
+                              "$id": "35",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Faction, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": []
+                              },
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 0,
+                              "PreviousField": null,
+                              "PreviousFieldID": -1,
+                              "ActionFieldID": 4,
+                              "NameID": "{4}:GetOrCreatePersonAction:faction",
+                              "ActionFieldIDString": "{4}",
+                              "ContextType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "gender": 0,
+                            "age": {
+                              "$id": "36",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 19,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "politicalPriority": {
+                              "$id": "37",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 19,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "economicPriority": {
+                              "$id": "38",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 9,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "religiousPriority": {
+                              "$id": "39",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 17,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "militaryPriority": {
+                              "$id": "40",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 13,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "influence": {
+                              "$id": "41",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 12,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "wealth": {
+                              "$id": "42",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 15,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "strength": {
+                              "$id": "43",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 15,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "dexterity": {
+                              "$id": "44",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 16,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "constitution": {
+                              "$id": "45",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 15,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "intelligence": {
+                              "$id": "46",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 17,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "wisdom": {
+                              "$id": "47",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 5,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "charisma": {
+                              "$id": "48",
+                              "$type": "Game.Incidents.IntegerRange, Assembly-CSharp",
+                              "randomRange": true,
+                              "min": 0,
+                              "max": 20,
+                              "constant": 0,
+                              "Value": 14,
+                              "GetValueType": "System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                            },
+                            "worldPlayer": true,
+                            "generateFamily": true,
+                            "findFirst": true,
+                            "allowCreate": false,
+                            "actionField": {
+                              "$id": "49",
+                              "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+                              "parentType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                              "AllowSelf": false,
+                              "AllowNull": false,
+                              "criteria": {
+                                "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                "$values": [
+                                  {
+                                    "$id": "50",
+                                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                                    "propertyName": "AffiliatedFaction",
+                                    "evaluator": {
+                                      "$id": "51",
+                                      "$type": "Game.Incidents.FactionEvaluator, Assembly-CSharp",
+                                      "compareTo": {
+                                        "$id": "52",
+                                        "$type": "Game.Incidents.InterfacedIncidentActionFieldContainer`1[[Game.Incidents.IFactionAffiliated, Assembly-CSharp]], Assembly-CSharp",
+                                        "contextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                        "actionField": {
+                                          "$id": "53",
+                                          "$type": "Game.Incidents.ContextualIncidentActionField`1[[Game.Incidents.Person, Assembly-CSharp]], Assembly-CSharp",
+                                          "parentType": null,
+                                          "AllowSelf": false,
+                                          "AllowNull": false,
+                                          "criteria": {
+                                            "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp]], mscorlib",
+                                            "$values": []
+                                          },
+                                          "value": null,
+                                          "delayedValue": null,
+                                          "Method": 1,
+                                          "PreviousField": "{0} - Original Context",
+                                          "PreviousFieldID": 0,
+                                          "ActionFieldID": -1,
+                                          "NameID": null,
+                                          "ActionFieldIDString": "{-1}",
+                                          "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                        }
+                                      },
+                                      "propertyName": "AffiliatedFaction",
+                                      "Comparator": "!=",
+                                      "Type": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                      "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                    },
+                                    "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "PrimitiveType": "Game.Incidents.Faction, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                  },
+                                  {
+                                    "$id": "54",
+                                    "$type": "Game.Incidents.IncidentActionFieldCriteria, Assembly-CSharp",
+                                    "propertyName": "WorldPlayer",
+                                    "evaluator": {
+                                      "$id": "55",
+                                      "$type": "Game.Incidents.BoolEvaluator, Assembly-CSharp",
+                                      "propertyName": "WorldPlayer",
+                                      "Comparator": "==",
+                                      "expressions": {
+                                        "$type": "System.Collections.Generic.List`1[[Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp]], mscorlib",
+                                        "$values": [
+                                          {
+                                            "$id": "56",
+                                            "$type": "Game.Incidents.Expression`1[[System.Boolean, mscorlib]], Assembly-CSharp",
+                                            "hasNextOperator": false,
+                                            "ExpressionType": 0,
+                                            "constValue": true,
+                                            "chosenMethod": null,
+                                            "chosenProperty": null,
+                                            "range": {
+                                              "$id": "57",
+                                              "$type": "Game.Incidents.BoolRange, Assembly-CSharp",
+                                              "Value": false,
+                                              "GetValueType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                            },
+                                            "subexpressions": null,
+                                            "previousCalculatedID": null,
+                                            "rangeWarning": "Range not implemented for non integers!",
+                                            "nextOperator": null,
+                                            "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                                          }
+                                        ]
+                                      },
+                                      "Type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                                      "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                      "AllowMultipleExpressions": true
+                                    },
+                                    "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                                    "PrimitiveType": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                                  }
+                                ]
+                              },
+                              "value": null,
+                              "delayedValue": null,
+                              "Method": 0,
+                              "PreviousField": null,
+                              "PreviousFieldID": -1,
+                              "ActionFieldID": 5,
+                              "NameID": "{5}:GetOrCreatePersonAction:actionField",
+                              "ActionFieldIDString": "{5}",
+                              "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                            },
+                            "ResultID": "{5}"
+                          }
+                        }
+                      ]
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                },
+                {
+                  "$id": "58",
+                  "$type": "Game.Incidents.IncidentActionBranch, Assembly-CSharp",
+                  "weightModifier": {
+                    "$id": "59",
+                    "$type": "Game.Incidents.IncidentActionBranchWeightModifier, Assembly-CSharp",
+                    "advancedMode": false,
+                    "baseWeight": 1,
+                    "container": {
+                      "$id": "60",
+                      "$type": "Game.Incidents.IncidentActionFieldContainer, Assembly-CSharp",
+                      "contextType": null,
+                      "actionField": null
+                    },
+                    "weight": null
+                  },
+                  "actionHandler": {
+                    "$id": "61",
+                    "$type": "Game.Incidents.IncidentActionHandlerContainer, Assembly-CSharp",
+                    "incidentLog": "There are no leads as to who the killer might be.",
+                    "Actions": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IncidentActionHandler, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "Deployers": {
+                      "$type": "System.Collections.Generic.List`1[[Game.Incidents.IContextDeployer, Assembly-CSharp]], mscorlib",
+                      "$values": []
+                    },
+                    "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                  },
+                  "ContextType": "Game.Incidents.Person, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+                }
+              ]
             }
           }
         }

--- a/Assets/Resources/ScriptableObjects/Names/Presets/CreatureTheme.asset
+++ b/Assets/Resources/ScriptableObjects/Names/Presets/CreatureTheme.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 92bd115edc971ee42a10b4b9462e4827, type: 3}
-  m_Name: MonsterTheme
+  m_Name: CreatureTheme
   m_EditorClassIdentifier: 
   serializationData:
     SerializedFormat: 2
@@ -40,7 +40,7 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 3
-      Data: 5
+      Data: 1
     - Name: $v
       Entry: 7
       Data: 2|System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib
@@ -67,49 +67,7 @@ MonoBehaviour:
       Data: 
     - Name: surnameFormats
       Entry: 7
-      Data: 3|Unity.Cloud.Collaborate.Common.SerializableDictionary`2[[System.Int32,
-        mscorlib],[System.Collections.Generic.List`1[[System.String, mscorlib]],
-        mscorlib]], Unity.CollabProxy.Editor
-    - Name: comparer
-      Entry: 7
-      Data: 4|System.Collections.Generic.GenericEqualityComparer`1[[System.Int32,
-        mscorlib]], mscorlib
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 12
-      Data: 1
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 3
-      Data: 1
-    - Name: $v
-      Entry: 7
-      Data: 5|System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 0
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: townNameFormats
-      Entry: 7
-      Data: 6|System.Collections.Generic.Dictionary`2[[System.Int32, mscorlib],[System.Collections.Generic.List`1[[System.String,
+      Data: 3|System.Collections.Generic.Dictionary`2[[System.Int32, mscorlib],[System.Collections.Generic.List`1[[System.String,
         mscorlib]], mscorlib]], mscorlib
     - Name: comparer
       Entry: 9
@@ -122,10 +80,10 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 3
-      Data: 5
+      Data: 1
     - Name: $v
       Entry: 7
-      Data: 7|System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib
+      Data: 4|System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
@@ -147,9 +105,25 @@ MonoBehaviour:
     - Name: 
       Entry: 8
       Data: 
+    - Name: townNameFormats
+      Entry: 7
+      Data: 5|System.Collections.Generic.Dictionary`2[[System.Int32, mscorlib],[System.Collections.Generic.List`1[[System.String,
+        mscorlib]], mscorlib]], mscorlib
+    - Name: comparer
+      Entry: 9
+      Data: 1
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: factionNameFormats
       Entry: 7
-      Data: 8|System.Collections.Generic.Dictionary`2[[System.Int32, mscorlib],[System.Collections.Generic.List`1[[System.String,
+      Data: 6|System.Collections.Generic.Dictionary`2[[System.Int32, mscorlib],[System.Collections.Generic.List`1[[System.String,
         mscorlib]], mscorlib]], mscorlib
     - Name: comparer
       Entry: 9
@@ -162,10 +136,10 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 3
-      Data: 5
+      Data: 1
     - Name: $v
       Entry: 7
-      Data: 9|System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib
+      Data: 7|System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1

--- a/Assets/Resources/ScriptableObjects/Names/Presets/CreatureTheme.asset.meta
+++ b/Assets/Resources/ScriptableObjects/Names/Presets/CreatureTheme.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3b986edcfb108ff42865cbad56bf1c78
+guid: 5a66e336383ab204eadfcf4d21373d12
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/Resources/ScriptableObjects/Names/Presets/HumanTheme.asset
+++ b/Assets/Resources/ScriptableObjects/Names/Presets/HumanTheme.asset
@@ -122,7 +122,31 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 0
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 3
+      Data: 1
+    - Name: $v
+      Entry: 7
+      Data: 8|System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 1
+      Data: '{T}'
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: 
       Entry: 13
       Data: 
@@ -131,7 +155,7 @@ MonoBehaviour:
       Data: 
     - Name: factionNameFormats
       Entry: 7
-      Data: 8|System.Collections.Generic.Dictionary`2[[System.Int32, mscorlib],[System.Collections.Generic.List`1[[System.String,
+      Data: 9|System.Collections.Generic.Dictionary`2[[System.Int32, mscorlib],[System.Collections.Generic.List`1[[System.String,
         mscorlib]], mscorlib]], mscorlib
     - Name: comparer
       Entry: 9
@@ -147,7 +171,7 @@ MonoBehaviour:
       Data: 5
     - Name: $v
       Entry: 7
-      Data: 9|System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib
+      Data: 10|System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1

--- a/Assets/Scenes/Scene.unity
+++ b/Assets/Scenes/Scene.unity
@@ -10253,7 +10253,7 @@ MonoBehaviour:
     - Name: 
       Entry: 8
       Data: 
-  monsterPreset: {fileID: 11400000, guid: 3b986edcfb108ff42865cbad56bf1c78, type: 2}
+  monsterPreset: {fileID: 11400000, guid: 5a66e336383ab204eadfcf4d21373d12, type: 2}
 --- !u!1 &1287639886
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GUI/IncidentWiki.cs
+++ b/Assets/Scripts/GUI/IncidentWiki.cs
@@ -90,7 +90,7 @@ namespace Game.GUI.Wiki
 			if(!pages.ContainsKey(id))
 			{
 				//Get the context in question
-				var context = id == 0 ? SimulationManager.Instance.world : SimulationManager.Instance.Contexts.GetContextByID(id);
+				var context = id == 0 ? SimulationManager.Instance.world : SimulationManager.Instance.AllContexts.GetContextByID(id);
 				if (context != null)
 				{
 					//make a new page
@@ -132,6 +132,7 @@ namespace Game.GUI.Wiki
 
 		private void AddReportToPage(IncidentWikiPage page, IncidentReport report)
 		{
+			page.wikiText.text += report.ReportYear + ": ";
 			page.wikiText.text += report.GenerateLinkedLog();
 			page.wikiText.text += "\n";
 		}

--- a/Assets/Scripts/Incidents/Contexts/Person.cs
+++ b/Assets/Scripts/Incidents/Contexts/Person.cs
@@ -162,11 +162,15 @@ namespace Game.Incidents
 			{
 				if(Parents.Count(x => x.Gender == Gender.MALE) < 1)
 				{
-					Parents.Add(new Person(Gender.MALE, Race, AffiliatedFaction, false));
+					var father = new Person(Gender.MALE, Race, AffiliatedFaction, false);
+					Parents.Add(father);
+					SimulationManager.Instance.world.AddContext(father);
 				}
 				if(Parents.Count(x => x.Gender == Gender.FEMALE) < 1)
 				{
-					Parents.Add(new Person(Gender.FEMALE, Race, AffiliatedFaction, false));
+					var mother = new Person(Gender.FEMALE, Race, AffiliatedFaction, false);
+					Parents.Add(mother);
+					SimulationManager.Instance.world.AddContext(mother);
 				}
 			}
 			if(canGenerateSpouse && Spouses.Count == 0)
@@ -174,7 +178,9 @@ namespace Game.Incidents
 				if(SimRandom.RandomBool())
 				{
 					var gender = Gender == Gender.MALE ? Gender.FEMALE : Gender.MALE;
-					Spouses.Add(new Person(gender, Race, AffiliatedFaction, false));
+					var spouse = new Person(gender, Race, AffiliatedFaction, false);
+					Spouses.Add(spouse);
+					SimulationManager.Instance.world.AddContext(spouse);
 				}
 			}
 			if (Siblings.Count == 0)
@@ -183,7 +189,9 @@ namespace Game.Incidents
 				var numSiblings = SimRandom.RandomRange(0, 5);
 				for (int i = 0; i < numSiblings; i++)
 				{
-					Siblings.Add(new Person(Gender.ANY, Race, AffiliatedFaction, false, Parents));
+					var sibling = new Person(Gender.ANY, Race, AffiliatedFaction, false, Parents);
+					Siblings.Add(sibling);
+					SimulationManager.Instance.world.AddContext(sibling);
 				}
 			}
 		}
@@ -197,4 +205,6 @@ namespace Game.Incidents
 			EventManager.Instance.Dispatch(new RemoveContextEvent(this));
 		}
 	}
+
+	//add years to wiki and find out why non world players arent dying
 }

--- a/Assets/Scripts/Incidents/CriteriaEvaluators/ContextEvaluator.cs
+++ b/Assets/Scripts/Incidents/CriteriaEvaluators/ContextEvaluator.cs
@@ -13,7 +13,7 @@ namespace Game.Incidents
 		override public bool Evaluate(IIncidentContext context, string propertyName, IIncidentContext parentContext)
 		{
 			compareTo.actionField.CalculateField(context);
-			var parentValue = compareTo.actionField.GetFieldValue();
+			var parentValue = GetContext(compareTo.actionField.GetFieldValue());
 			var contextValue = GetContext(context);
 
 			return Comparators[Comparator].Invoke(parentValue, contextValue);

--- a/Assets/Scripts/Incidents/IncidentActions/ActionFields/ContextualIncidentActionField.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/ActionFields/ContextualIncidentActionField.cs
@@ -112,11 +112,11 @@ namespace Game.Incidents
 			List<IIncidentContext> possibleMatches;
 			if (AllowSelf)
 			{
-				possibleMatches = SimulationManager.Instance.Contexts[typeof(T)].Where(x => criteriaContainer.Evaluate(x, context) == true).ToList();
+				possibleMatches = SimulationManager.Instance.CurrentContexts[typeof(T)].Where(x => criteriaContainer.Evaluate(x, context) == true).ToList();
 			}
 			else
 			{
-				possibleMatches = SimulationManager.Instance.Contexts[typeof(T)].Where(x => x != context && criteriaContainer.Evaluate(x, context) == true).ToList();
+				possibleMatches = SimulationManager.Instance.CurrentContexts[typeof(T)].Where(x => x != context && criteriaContainer.Evaluate(x, context) == true).ToList();
 			}
 
 			return possibleMatches.Count > 0 ? SimRandom.RandomEntryFromList(possibleMatches) : null;
@@ -126,12 +126,12 @@ namespace Game.Incidents
 		{
 			if (AllowSelf)
 			{
-				var possibleValues = SimulationManager.Instance.Contexts[typeof(T)];
+				var possibleValues = SimulationManager.Instance.CurrentContexts[typeof(T)];
 				return SimRandom.RandomEntryFromList(possibleValues);
 			}
 			else
 			{
-				var possibleValues = SimulationManager.Instance.Contexts[typeof(T)].Where(x => x != context).ToList();
+				var possibleValues = SimulationManager.Instance.CurrentContexts[typeof(T)].Where(x => x != context).ToList();
 				return SimRandom.RandomEntryFromList(possibleValues);
 			}
 		}

--- a/Assets/Scripts/Incidents/IncidentActions/BranchingAction.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/BranchingAction.cs
@@ -35,16 +35,17 @@ namespace Game.Incidents
 			{
 				totalWeight += branch.weightModifier.Calculate();
 			}
-			var decider = SimRandom.RandomRange(0, totalWeight+1);
+			var randomWeight = SimRandom.RandomRange(1, totalWeight+1);
 			for(int i = 0; i < branches.Count; i++)
 			{
-				totalWeight -= branches[i].weightModifier.Calculate();
-				if(decider > totalWeight)
+				randomWeight -= branches[i].weightModifier.Calculate();
+				if(randomWeight <= 0)
 				{
 					branches[i].PerformActions(context, ref report);
 					return;
 				}
 			}
+			return;
 		}
 
 		override public void UpdateEditor()

--- a/Assets/Scripts/Simulation/SimulationManager.cs
+++ b/Assets/Scripts/Simulation/SimulationManager.cs
@@ -38,7 +38,8 @@ namespace Game.Simulation
 		}
 
 
-		public IncidentContextDictionary Contexts => world.AllContexts;
+		public IncidentContextDictionary CurrentContexts => world.CurrentContexts;
+		public IncidentContextDictionary AllContexts => world.AllContexts;
 
 		public void CreateWorld(List<FactionPreset> factions)
 		{


### PR DESCRIPTION
Identified and knocked out some bugs with a few incident related systems:
- Fixed a broken naming theme SO
- Fixed improper weight calculations for branching actions
- Fixed `ContextualIncidentActionField` to look only at Current Contexts
- Fixed a bug where generated families weren't added to context pool
- Fixed a bug where context evaluators weren't properly converting both contexts before comparing

Also made the wiki show the year of each event for ease of debugging later