### PR TITLE
06-24-2023 Second round FlavorService

### DIFF
--- a/Assets/Resources/ThesaurusData.meta
+++ b/Assets/Resources/ThesaurusData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fcf23750db20cb9488511901310d0ae9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/ThesaurusData/thesaurus.json
+++ b/Assets/Resources/ThesaurusData/thesaurus.json
@@ -1,0 +1,13 @@
+{
+  "$id": "1",
+  "$type": "System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib]], mscorlib",
+  "MAD": {
+    "$type": "System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib",
+    "$values": [
+      "huffy",
+      "sore",
+      "angry",
+      "mad"
+    ]
+  }
+}

--- a/Assets/Resources/ThesaurusData/thesaurus.json.meta
+++ b/Assets/Resources/ThesaurusData/thesaurus.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 07e047c9d69fb634bb7351b37ab194e5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enums.cs
+++ b/Assets/Scripts/Enums.cs
@@ -33,6 +33,8 @@ namespace Game.Enums
 	public enum HexEdgeType { Flat, Slope, Cliff };
 	public enum LandmarkType { NONE, TOWER, STATUE };
 
+	public enum FlavorType { SYNONYM, REASON };
+
 	public static class EnumHelpers
 	{
 		internal static IEnumerable<T> ToEnumerableOf<T>(this Enum theEnum)

--- a/Assets/Scripts/Incidents/Contexts/ContextFlavor/FlavorService.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextFlavor/FlavorService.cs
@@ -37,6 +37,34 @@ namespace Game.Incidents
 			return final;
 		}
 
+		//unsure exactly where i left off with this part - we can now use synonyms but i need a way to cleanly
+		//regex which matches to make instead of having separate fns for each and checking them all
+		public string GenerateFlavor_2(string phrase)
+		{
+			var matches = Regex.Matches(phrase, @"\{([^\n \{\}]+):(GOOD|EVIL|LAWFUL|CHAOTIC)\}");
+			foreach (Match match in matches)
+			{
+				var flavorTypeString = match.Groups[1].Value.ToString();
+				if (Enum.TryParse<FlavorType>(flavorTypeString, out FlavorType flavorType))
+				{
+					var alignmentString = match.Groups[2].Value.ToString();
+					if(Enum.TryParse<CreatureAlignment>(alignmentString, out CreatureAlignment alignment))
+					{
+						phrase = GenerateAlignmentBasedFlavor(flavorType, alignment, match.Value, phrase);
+					}
+				}
+			}
+
+			return phrase;
+		}
+
+		private string GenerateAlignmentBasedFlavor(FlavorType flavorType, CreatureAlignment alignment, string match, string phrase)
+		{
+			var tempDict = new Dictionary<FlavorType, Dictionary<CreatureAlignment, List<string>>>();
+			var flavor = SimRandom.RandomEntryFromList(tempDict[flavorType][alignment]);
+			return StringUtilities.ReplaceFirstOccurence(phrase, match, flavor);
+		}
+
 		private string GenerateReasons(string phrase)
 		{
 			var matches = Regex.Matches(phrase, @"\{R:(GOOD|EVIL|LAWFUL|CHAOTIC)\}");

--- a/Assets/Scripts/Incidents/Contexts/ContextFlavor/ThesaurusEntryRetriever.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextFlavor/ThesaurusEntryRetriever.cs
@@ -1,0 +1,52 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Game.Incidents
+{
+	static public class ThesaurusEntryRetriever
+	{
+		public static ThesaurusObjectRoot GetSynonyms(string word)
+		{
+			var url = string.Format("http://thesaurus.altervista.org/thesaurus/v1?word={0}&language=en_US&key={1}&output=json", word, "dB0XpkI8WTt8ZZ06IONW");
+			var httpClientHandler = new HttpClientHandler();
+			var httpClient = new HttpClient(httpClientHandler)
+			{
+				BaseAddress = new Uri(url)
+			};
+			using (var response = httpClient.GetAsync(url))
+			{
+				string responseBody = response.Result.Content.ReadAsStringAsync().Result;
+				var item = JsonConvert.DeserializeObject<ThesaurusObjectRoot>(responseBody);
+				return item;
+				/*
+				if(item.Containers.Count > 0)
+				{
+					ThesaurusProvider.AddEntry(word.ToUpper(), item.Containers[0].Entry);
+				}
+				*/
+			}
+		}
+
+		public class ThesaurusObjectRoot
+		{
+			[JsonProperty("response")]
+			public List<ThesaurusEntryContainer> Containers { get; set; }
+		}
+
+		public class ThesaurusEntryContainer
+		{
+			[JsonProperty("list")]
+			public ThesaurusEntry Entry { get; set; }
+		}
+	}
+
+	public class ThesaurusEntry
+	{
+		[JsonProperty("category")]
+		public string Category { get; set; }
+		[JsonProperty("synonyms")]
+		public string SynonymsString { get; set; }
+	}
+}

--- a/Assets/Scripts/Incidents/Contexts/ContextFlavor/ThesaurusEntryRetriever.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextFlavor/ThesaurusEntryRetriever.cs
@@ -20,12 +20,6 @@ namespace Game.Incidents
 				string responseBody = response.Result.Content.ReadAsStringAsync().Result;
 				var item = JsonConvert.DeserializeObject<ThesaurusObjectRoot>(responseBody);
 				return item;
-				/*
-				if(item.Containers.Count > 0)
-				{
-					ThesaurusProvider.AddEntry(word.ToUpper(), item.Containers[0].Entry);
-				}
-				*/
 			}
 		}
 

--- a/Assets/Scripts/Incidents/Contexts/ContextFlavor/ThesaurusEntryRetriever.cs.meta
+++ b/Assets/Scripts/Incidents/Contexts/ContextFlavor/ThesaurusEntryRetriever.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e4169b95e00837429c7107e421ebb65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Contexts/ContextFlavor/ThesaurusProvider.cs
+++ b/Assets/Scripts/Incidents/Contexts/ContextFlavor/ThesaurusProvider.cs
@@ -1,0 +1,88 @@
+﻿using Game.Utilities;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Game.Incidents
+{
+	static public class ThesaurusProvider
+	{
+		private static string THESAURUS_FILE_NAME = "thesaurus.json";
+		public static Dictionary<string, List<string>> Thesaurus
+		{
+			get
+			{
+				if(thesaurus == null || thesaurus.Count == 0)
+				{
+					LoadThesaurus();
+				}
+				return thesaurus;
+			}
+			private set
+			{
+				thesaurus = value;
+			}
+		}
+		private static Dictionary<string, List<string>> thesaurus;
+
+		public static void LoadThesaurus()
+		{
+			var dataPath = Path.Combine(Application.dataPath + SaveUtilities.THESAURUS_DATA_PATH);
+			var files = Directory.GetFiles(dataPath, THESAURUS_FILE_NAME);
+			if(files.Length <= 0)
+			{
+				thesaurus = new Dictionary<string, List<string>>();
+				return;
+			}
+			var file = files[0];
+			var text = File.ReadAllText(file);
+
+			thesaurus = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(text, SaveUtilities.SERIALIZER_SETTINGS);
+		}
+
+		public static void SaveThesaurus()
+		{
+			if(thesaurus == null)
+			{
+				return;
+			}
+			var path = Path.Combine(Application.dataPath + SaveUtilities.THESAURUS_DATA_PATH + THESAURUS_FILE_NAME);
+			string output = JsonConvert.SerializeObject(thesaurus, Formatting.Indented, SaveUtilities.SERIALIZER_SETTINGS);
+			File.WriteAllText(path, output);
+
+			AssetDatabase.Refresh();
+		}
+
+		public static bool AddEntry(string key, List<string> entries)
+		{
+			key = key.ToUpper();
+			if(!Thesaurus.ContainsKey(key))
+			{
+				Thesaurus.Add(key, entries);
+				Thesaurus[key].Add(key.ToLower());
+			}
+			else
+			{
+				foreach(var entry in entries)
+				{
+					if(!Thesaurus[key].Contains(entry))
+					{
+						Thesaurus[key].Add(entry);
+					}
+				}
+			}
+
+			SaveThesaurus();
+			return true;
+		}
+
+		public static List<string> ConvertEntryToStringList(string entry)
+		{
+			var actualSynonyms = entry.Split()[0];
+			return actualSynonyms.Split('|').ToList();
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/Contexts/ContextFlavor/ThesaurusProvider.cs.meta
+++ b/Assets/Scripts/Incidents/Contexts/ContextFlavor/ThesaurusProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 007f703713fa5b6439510cb682ceee32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/Editor/LearnAboutReflectionEditor.cs
+++ b/Assets/Scripts/Incidents/Editor/LearnAboutReflectionEditor.cs
@@ -7,8 +7,11 @@ using System.Reflection;
 using System.Collections.Generic;
 using Game.Simulation;
 using System.Data;
-using System.IO;	
+using System.IO;
 using Game.Generators.Names;
+using Game.Utilities;
+using Newtonsoft.Json;
+using System.Text.RegularExpressions;
 
 namespace Game.Incidents
 {
@@ -30,18 +33,15 @@ namespace Game.Incidents
 				test.TestName();
 			}
 
-			if (GUILayout.Button("Govt Test"))
+			if (GUILayout.Button("Flavor Test"))
 			{
-				var govt = new Organization(null, null, Enums.OrganizationType.POLITICAL);
-				for(int i = 0; i < 40; i++)
-				{
-					govt.UpdateHierarchy();
-				}
-				OutputLogger.Log(string.Format("Number of Tiers: {0}", govt.hierarchy.Count));
-				for(int i = 0; i < govt.hierarchy.Count; i++)
-				{
-					OutputLogger.Log(string.Format("Number of Positions in Tier {0}: {1}", i, govt.hierarchy[i].Count));
-				}
+				var phrase = "{1} {1.5] [2} [3] {4} {R:GOOD} {STROMBOLI}";
+				GenerateFlavor(phrase);
+			}
+
+			if (GUILayout.Button("Thesaurus Test"))
+			{
+				ThesaurusEntryRetriever.GetSynonyms("mad");
 			}
 		}
 		public static IEnumerable<Type> GetAllTypesImplementingOpenGenericType(Type openGenericType, Assembly assembly)
@@ -55,6 +55,23 @@ namespace Game.Incidents
 				   (z.IsGenericType &&
 				   openGenericType.IsAssignableFrom(z.GetGenericTypeDefinition()))
 				   select x;
+		}
+
+		public string GenerateFlavor(string phrase)
+		{
+			var matches = Regex.Matches(phrase, @"\{[^\n \{\}]+\}");
+			foreach(Match match in matches)
+			{
+				OutputLogger.Log(" %%: " + match.Value);
+			}
+
+			matches = Regex.Matches(phrase, @"\{([^\n \{\}]+):(GOOD|EVIL|LAWFUL|CHAOTIC)\}");
+			foreach (Match match in matches)
+			{
+				OutputLogger.Log(" %%: " + match.Value);
+			}
+
+			return phrase;
 		}
 	}
 

--- a/Assets/Scripts/Incidents/FlavorEditorWindow.cs
+++ b/Assets/Scripts/Incidents/FlavorEditorWindow.cs
@@ -1,0 +1,154 @@
+﻿using Game.Enums;
+using Sirenix.OdinInspector;
+using Sirenix.OdinInspector.Editor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEngine;
+
+namespace Game.Incidents
+{
+	public class FlavorEditorWindow : OdinEditorWindow
+	{
+        public static FlavorEditorWindow Instance = null;
+
+        private Dictionary<FlavorType, Func<string>> FlavorValues = new Dictionary<FlavorType, Func<string>>()
+        { 
+            { FlavorType.SYNONYM, () => Instance.synonymKey },
+            { FlavorType.REASON, () => Instance.alignment.ToString() }
+        };
+
+        [MenuItem("World Builder/Flavor Editor")]
+        public static void OpenWindow()
+		{
+            var window = GetWindow<FlavorEditorWindow>("FlavorEditor");
+            window.minSize = new Vector2(300, 650);
+            window.maxSize = new Vector2(550, 900);
+            AssetDatabase.Refresh();
+            //window.position = new Rect(new Vector2(posX, posY), new Vector2(900, 650));
+        }
+
+        private string GS()
+		{
+            return synonymKey;
+		}
+
+        public FlavorEditorWindow()
+		{
+            Instance = this;
+		}
+
+        protected override void OnGUI()
+        {
+            base.OnGUI();
+        }
+
+        [ValueDropdown("GetFlavorTypes")]
+        public FlavorType flavorType;
+        
+        [ShowIf("@this.ShouldShowSynonymKeyDropdown"), ValueDropdown("GetSynonymKeys")]
+        public string synonymKey;
+
+        [Button("Add New Synonym Entry", ButtonSizes.Medium), ShowIf("@this.ShouldShowNewSynonymEntryButton")]
+        public void OpenNewEntryPopup()
+		{
+            NewThesaurusEntryWindow.OpenWindow();
+		}
+
+        [ShowIf("ShouldShowAlignment")]
+        public CreatureAlignment alignment;
+
+        [Button("Copy To Clipboard", ButtonSizes.Medium), ShowIf("ShouldShowCopyToClipboardButton")]
+        public void CopyToClipboard()
+        {
+            var bfs = BuildFlavorString();
+            GUIUtility.systemCopyBuffer = BuildFlavorString();
+        }
+
+        private string BuildFlavorString()
+		{
+            var flavorString = "{" + flavorType.ToString();
+            if(FlavorValues.TryGetValue(flavorType, out var value))
+			{
+                flavorString += (":" + value.Invoke());
+			}
+            flavorString += "}";
+
+            return Regex.Replace(flavorString, @"\s", string.Empty);
+        }
+
+        private IEnumerable<FlavorType> GetFlavorTypes()
+		{
+            return Enum.GetValues(typeof(FlavorType)).Cast<FlavorType>();
+        }
+
+        private IEnumerable<string> GetSynonymKeys()
+		{
+            var list = new List<string>() { "-" };
+            list.AddRange(ThesaurusProvider.Thesaurus.Keys.ToList());
+            return list;
+		}
+
+        private IEnumerable<CreatureAlignment> GetAlignments()
+        {
+            return Enum.GetValues(typeof(CreatureAlignment)).Cast<CreatureAlignment>();
+        }
+
+        private bool ShouldShowSynonymKeyDropdown => flavorType == FlavorType.SYNONYM;
+        private bool ShouldShowNewSynonymEntryButton => ShouldShowSynonymKeyDropdown && synonymKey == "-";
+        private bool ShouldShowCopyToClipboardButton()
+        {
+            return (flavorType == FlavorType.SYNONYM && synonymKey != "-") ||
+                (flavorType == FlavorType.REASON);
+        }
+
+        private bool ShouldShowAlignment()
+		{
+            return flavorType == FlavorType.REASON;
+		}
+    }
+
+	public class NewThesaurusEntryWindow : OdinEditorWindow
+	{
+        public string entry;
+        [ShowIf("@this.newEntries.Count > 0")]
+        public List<NewThesaurusEntry> newEntries = new List<NewThesaurusEntry>();
+
+        [Button(ButtonSizes.Medium)]
+        public void AddEntry()
+		{
+            if(ThesaurusProvider.Thesaurus.ContainsKey(entry.ToUpper()))
+            {
+                OutputLogger.LogError($"Thesaurus already contains entries for {entry}");
+                return;
+            }
+
+            var root = ThesaurusEntryRetriever.GetSynonyms(entry);
+
+            if (root == null || root.Containers.Count == 0)
+			{
+                OutputLogger.LogError($"{entry} did not return any valid synonyms.");
+                return;
+			}
+
+            foreach(var container in root.Containers)
+			{
+                newEntries.Add(new NewThesaurusEntry(entry, container.Entry, RemoveEntry));
+			}
+		}
+
+        public static void OpenWindow()
+        {
+            var window = GetWindow<NewThesaurusEntryWindow>("NewThesaurusEntryWindow");
+            window.minSize = new Vector2(300, 450);
+            window.maxSize = new Vector2(550, 700);
+        }
+
+        private void RemoveEntry(NewThesaurusEntry entry)
+		{
+            newEntries.Remove(entry);
+		}
+    }
+}

--- a/Assets/Scripts/Incidents/FlavorEditorWindow.cs.meta
+++ b/Assets/Scripts/Incidents/FlavorEditorWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56d508564f455f24eb76d4df7febda17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Incidents/IncidentActions/IncidentActionHandlerContainer.cs
+++ b/Assets/Scripts/Incidents/IncidentActions/IncidentActionHandlerContainer.cs
@@ -34,7 +34,8 @@ namespace Game.Incidents
 			{
 				if (!action.VerifyAction(context))
 				{
-					OutputLogger.LogWarning("ActionContainer failed to verify action context!");
+					OutputLogger.LogWarning($"ActionContainer failed to verify {context.GetType().Name} : {context.Name} for" +
+						$" {action.incidentAction.GetType().Name} as part of {IncidentService.Instance.CurrentIncident.IncidentName}!");
 					return false;
 				}
 			}

--- a/Assets/Scripts/Incidents/IncidentEditorWindow.cs
+++ b/Assets/Scripts/Incidents/IncidentEditorWindow.cs
@@ -21,6 +21,11 @@ namespace Game.Incidents
 			var window = GetWindow<IncidentEditorWindow>("Incident Editor");
             window.minSize = new Vector2(900, 650);
             window.maxSize = new Vector2(1200, 900);
+
+            if(FlavorEditorWindow.Instance == null)
+			{
+                FlavorEditorWindow.OpenWindow();
+			}
 		}
 
 		protected override void OnGUI()

--- a/Assets/Scripts/Incidents/NewThesaurusEntry.cs
+++ b/Assets/Scripts/Incidents/NewThesaurusEntry.cs
@@ -1,0 +1,31 @@
+﻿using Sirenix.OdinInspector;
+using System;
+using System.Collections.Generic;
+
+namespace Game.Incidents
+{
+	[HideReferenceObjectPicker]
+    public class NewThesaurusEntry
+	{
+        public string key;
+        [HideReferenceObjectPicker]
+        public List<string> entries;
+        private Action<NewThesaurusEntry> onComplete;
+
+        public NewThesaurusEntry(string key, ThesaurusEntry entry, Action<NewThesaurusEntry> onComplete)
+		{
+            this.key = key;
+            this.entries = ThesaurusProvider.ConvertEntryToStringList(entry.SynonymsString);
+            this.onComplete = onComplete;
+		}
+
+        [Button("Add Entry")]
+        public void AddEntry()
+		{
+            if(ThesaurusProvider.AddEntry(key, entries))
+			{
+                onComplete.Invoke(this);
+			}
+		}
+	}
+}

--- a/Assets/Scripts/Incidents/NewThesaurusEntry.cs.meta
+++ b/Assets/Scripts/Incidents/NewThesaurusEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfeeac0c771d5844b9f4db8a5b58fe17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utilities/SaveUtilities.cs
+++ b/Assets/Scripts/Utilities/SaveUtilities.cs
@@ -12,6 +12,7 @@ namespace Game.Utilities
 		const int mapFileVersion = 4;
 
 		public static string INCIDENT_DATA_PATH = "/Resources/IncidentData/";
+		public static string THESAURUS_DATA_PATH = "/Resources/ThesaurusData/";
 		public static string ENCOUNTER_DATA_PATH = "/Resources/ScriptableObjects/Encounters";
 		public static string RESOURCES_DATA_PATH = "/Resources/";
 		public static string SCRIPTABLE_OBJECTS_PATH = "/Resources/ScriptableObjects/";


### PR DESCRIPTION
Took a small break to theory craft some ways to generate more flavor in the `IncidentLogs`. For now I just ended up adding the concept of synonyms, including a locally stored thesaurus via the `ThesaurusProvider`. 
I also didn't relish the idea of manually entering all of the synonyms myself, so I created a small service to pull synonyms from the internet and deposit them into a dictionary. Look into `ThesaurusEntryProvider` for more details.
There's also now a `FlavorEditorWindow` to aid in adding the flavor placeholder strings, but while I had initially planned for it to be able to inline add the strings to the last selected string field, it seems that Unity doesn't really have any way to do that, so instead it generates the replacement string and adds it to the system clipboard so that you can paste it where you want it. Not ideal, but a workable solution for now.